### PR TITLE
Fix bug when creating nested folders

### DIFF
--- a/src/pulp_docs/utils/aggregation.py
+++ b/src/pulp_docs/utils/aggregation.py
@@ -119,9 +119,10 @@ class AgregationUtils:
                     _repo_content = self.get_children(lookup_path)
 
                     # special treatment to quickstart tutorial
-                    quickstart_file = self._pop_quickstart_from(_repo_content)
-                    if content_type.lower() == "tutorials" and quickstart_file:
-                        repo_nav["Quickstart"] = quickstart_file  # type: ignore
+                    if content_type.lower() == "tutorials":
+                        quickstart_file = self._pop_quickstart_from(_repo_content)
+                        if quickstart_file:
+                            repo_nav["Quickstart"] = quickstart_file  # type: ignore
 
                     # doesnt render content-type section if no files inside
                     if _repo_content:
@@ -134,6 +135,9 @@ class AgregationUtils:
     def _pop_quickstart_from(self, pathlist: t.List[str]) -> t.Optional[str]:
         """Get quickstart.md file from filelist with case and variations tolerance"""
         for path in pathlist:
+            if not isinstance(path, str):
+                continue
+
             filename = path.split("/")[-1]
             if filename.lower() in ("quickstart.md", "quick-start.md"):
                 pathlist.remove(path)


### PR DESCRIPTION
An error would not allow to create nested folder under `{persona}/{content}`:

```
 File "/home/ipanova/.local/lib/python3.11/site-packages/pulp_docs/utils/aggregation.py", line 24, in section
    section = fn(*args, **kwargs)
              ^^^^^^^^^^^^^^^^^^^
  File "/home/ipanova/.local/lib/python3.11/site-packages/pulp_docs/utils/aggregation.py", line 122, in repo_grouping
    quickstart_file = self._pop_quickstart_from(_repo_content)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ipanova/.local/lib/python3.11/site-packages/pulp_docs/utils/aggregation.py", line 137, in _pop_quickstart_from
    filename = path.split("/")[-1]
               ^^^^^^^^^^
AttributeError: 'dict' object has no attribute 'split'
```