### PR TITLE
Replace underscore with space on dir name display

### DIFF
--- a/src/pulp_docs/utils/aggregation.py
+++ b/src/pulp_docs/utils/aggregation.py
@@ -45,12 +45,16 @@ class AgregationUtils:
                         filename = str(Path(entry.path).relative_to(self.tmpdir))
                         children.append(filename)
                     elif entry.is_dir():
-                        sub_section = {entry.name.title(): _get_tree(entry)}
+                        dir_title = self.normalize_title(entry.name)
+                        sub_section = {dir_title: _get_tree(entry)}
                         children.append(sub_section)
             return children
 
         result = _get_tree(basepath)
         return result
+
+    def normalize_title(self, raw_title: str):
+        return raw_title.replace("_", " ").title()
 
     def repo_grouping(
         self,


### PR DESCRIPTION
When there is a nested structure (a directory with markdown files inside), the following formatting will be applied to the dirname:
- Replace `_` (underscore) with ` ` (space)
- Title-case words

Example:

```
# File strcture
backup_and_restore/
    00_overview.md
    01_conclusion.md

# Display (on the website)
Backup And Restore
    <h1 for '00_overview.md'>
    <h1 for '01_conclusion.md'>
```