### PR TITLE
Section-level re-structures

### DIFF
--- a/src/pulp_docs/mkdocs_macros.py
+++ b/src/pulp_docs/mkdocs_macros.py
@@ -253,7 +253,21 @@ def define_env(env):
     @env.macro
     def get_repos(repo_type="content"):
         "Return repo names by type"
-        return sorted(repos.get_repos(repo_types=[repo_type]), key=lambda x: x.title)
+        _repo_type = [repo_type] if repo_type else None
+        repos_list = sorted(
+            repos.get_repos(repo_types=_repo_type), key=lambda x: x.title
+        )
+        repos_data = [
+            {
+                "title": repo.title,
+                "version": "3.12.1",
+                "rest_api": f"https://docs.pulpproject.org/{repo.name}/restapi.html",
+                "codebase_url": f"https://github.com/{repo.owner}/{repo.name}",
+                "changelog_url": f"site:pulp-docs/docs/sections/help/changelogs/{repo.name}.md",
+            }
+            for repo in repos_list
+        ]
+        return repos_data
 
 
 def on_pre_page_macros(env):

--- a/src/pulp_docs/mkdocs_macros.py
+++ b/src/pulp_docs/mkdocs_macros.py
@@ -135,14 +135,20 @@ def _place_doc_files(src_dir: Path, docs_dir: Path, repo: Repo):
     # Get CHANGELOG
     # TODO: remove reading .rst (plugins should provide markdown CHANGELOG)
     repo.status.has_changelog = False
+    changes_dir = Path(docs_dir / "changes")
+    changes_dir.mkdir(exist_ok=True)
     for changelog_name in ("CHANGELOG.md", "CHANGES.md", "CHANGES.rst"):
         changelog_path = Path(src_dir / changelog_name)
         if changelog_path.exists():
-            reference_dir = Path(docs_dir / "docs/reference")
-            reference_dir.mkdir(exist_ok=True)
-            shutil.copy(changelog_path, reference_dir / "CHANGELOG.md")
+            shutil.copy(changelog_path, changes_dir / "changelog.md")
             repo.status.has_changelog = True
-            break
+            return
+
+    # Create placeholder, case it was not possible to fetch one
+    empty_changelog = changes_dir / "changelog.md"
+    empty_changelog.write_text(
+        "# Changelog\n\nThe repository does not provide a changelog or there was a problem fetching it."
+    )
 
 
 def _generate_rest_api_page(docs_dir: Path, repo_name: str, repo_title: str):
@@ -261,9 +267,9 @@ def define_env(env):
             {
                 "title": repo.title,
                 "version": "3.12.1",
-                "rest_api": f"https://docs.pulpproject.org/{repo.name}/restapi.html",
+                "rest_api_url": f"https://docs.pulpproject.org/{repo.name}/restapi.html",
                 "codebase_url": f"https://github.com/{repo.owner}/{repo.name}",
-                "changelog_url": f"site:pulp-docs/docs/sections/help/changelogs/{repo.name}.md",
+                "changelog_url": f"site:{repo.name}/changes/changelog/",
             }
             for repo in repos_list
         ]

--- a/src/pulp_docs/navigation.py
+++ b/src/pulp_docs/navigation.py
@@ -56,16 +56,8 @@ def grouped_by_persona(tmpdir: Path, repos: Repos):
                     {content-type}
     """
     f = AgregationUtils(tmpdir, repos)
-    help_section = [
-        {"Overview": f.section_file("help/index.md")},
-        {
-            "Bugs, Feature and Backport Requests": f.section_file(
-                "help/bugs-features.md"
-            )
-        },
-    ]
     usage_section = [
-        {"Overview": f.section_file("usage/index.md")},
+        {"Overview": f.section_file("user/index.md")},
         {
             "Pulpcore": [
                 f.section(
@@ -113,7 +105,7 @@ def grouped_by_persona(tmpdir: Path, repos: Repos):
         ),
     ]
     development_section = [
-        {"Overview": f.section_file("development/index.md")},
+        {"Overview": f.section_file("dev/index.md")},
         {
             "Pulpcore": [
                 f.section(
@@ -132,13 +124,10 @@ def grouped_by_persona(tmpdir: Path, repos: Repos):
         },
         {"Extras": f.repo_grouping("{repo}/docs/dev/{content}", repo_types=["other"])},
     ]
-    reference_section = [
-        {"Overview": f.section_file("reference/index.md")},
-        {"Rest API": "pulp-docs/docs/rest_api.md"},
-        {"Glossary": f.section_file("reference/02-glossary.md")},
-        {"Pulpcore": f.section(Names.CORE, f.get_children, "pulpcore/docs/reference")},
-        {"Plugins": f.repo_grouping("{repo}/docs/reference", repo_types=["content"])},
-        {"Extra": f.repo_grouping("{repo}/docs/reference", repo_types=["other"])},
+    help_section = [
+        {"Overview": f.section_file("help/index.md")},
+        {"How to use this documentation": f.section_file("help/bugs-features.md")},
+        {"Changelog": f.repo_grouping("{repo}/CHANGES.md")},
     ]
 
     # Main Section
@@ -146,8 +135,7 @@ def grouped_by_persona(tmpdir: Path, repos: Repos):
         {"Home": "index.md"},
         {"User Manual": usage_section},
         {"Admin Manual": admin_section},
-        {"Development": development_section},
-        {"Reference": reference_section},
+        {"Developer Manual": development_section},
         {"Help": help_section},
     ]
     return navigation

--- a/src/pulp_docs/navigation.py
+++ b/src/pulp_docs/navigation.py
@@ -134,9 +134,11 @@ def grouped_by_persona(tmpdir: Path, repos: Repos):
     ]
     reference_section = [
         {"Overview": f.section_file("reference/index.md")},
-        {"Repository Map": f.section_file("reference/01-repository-map.md")},
+        {"Rest API": "pulp-docs/docs/rest_api.md"},
         {"Glossary": f.section_file("reference/02-glossary.md")},
-        {"Repositories": f.repo_reference_grouping()},
+        {"Pulpcore": f.section(Names.CORE, f.get_children, "pulpcore/docs/reference")},
+        {"Plugins": f.repo_grouping("{repo}/docs/reference", repo_types=["content"])},
+        {"Extra": f.repo_grouping("{repo}/docs/reference", repo_types=["other"])},
     ]
 
     # Main Section

--- a/src/pulp_docs/navigation.py
+++ b/src/pulp_docs/navigation.py
@@ -118,16 +118,30 @@ def grouped_by_persona(tmpdir: Path, repos: Repos):
             ]
         },
         {
-            "Plugins": f.repo_grouping(
-                "{repo}/docs/dev/{content}", repo_types=["content"]
-            )
-        },
+            "Plugins": f.repo_grouping( "{repo}/docs/dev/{content}", repo_types=["content"] ) },
         {"Extras": f.repo_grouping("{repo}/docs/dev/{content}", repo_types=["other"])},
     ]
     help_section = [
-        {"Overview": f.section_file("help/index.md")},
-        {"How to use this documentation": f.section_file("help/bugs-features.md")},
-        {"Changelog": f.repo_grouping("{repo}/CHANGES.md")},
+        *f.get_children("pulp-docs/docs/sections/help/community"),
+        {"Documentation Usage": f.get_children("pulp-docs/docs/sections/help/using-this-doc")},
+        {
+            "Changelogs": [
+                {"Pulpcore": "pulpcore/changes/changelog.md"},
+                {
+                    "Plugins": sorted(
+                        f.repo_grouping(
+                            "{repo}/changes", repo_types=["content"]
+                        ).items()
+                    )
+                },
+                {
+                    "Extra": sorted(
+                        f.repo_grouping("{repo}/changes", repo_types=["other"]).items()
+                    )
+                },
+            ]
+        },
+        {"Governance": f.get_children("pulp-docs/docs/sections/help/governance")},
     ]
 
     # Main Section

--- a/src/pulp_docs/repository.py
+++ b/src/pulp_docs/repository.py
@@ -203,6 +203,10 @@ class SubPackage:
     local_basepath = None
     branch_in_use = ""
     branch = ""
+    owner = ""
+
+    def __post_init__(self):
+        self.owner = self.subpackage_of
 
 
 @dataclass

--- a/src/pulp_docs/utils/aggregation.py
+++ b/src/pulp_docs/utils/aggregation.py
@@ -178,7 +178,7 @@ class AgregationUtils:
 
     def section_file(self, section_and_filename: str):
         """Get a markdown file from the website section folder."""
-        basepath = "pulpcore/docs/sections"
+        basepath = "pulp-docs/docs/sections"
         return f"{basepath}/{section_and_filename}"
 
     def section_children(self, section_name: str):

--- a/src/pulp_docs/utils/aggregation.py
+++ b/src/pulp_docs/utils/aggregation.py
@@ -1,6 +1,7 @@
 import os
 import typing as t
 from pathlib import Path
+import re
 
 from pulp_docs.constants import Names
 from pulp_docs.repository import Repos

--- a/src/pulp_docs/utils/aggregation.py
+++ b/src/pulp_docs/utils/aggregation.py
@@ -68,7 +68,7 @@ class AgregationUtils:
 
         Arguments:
             template_str: The template with fields to expand. Accepts combination of '{repo}' and '{content}'
-            repos: The set of repos to use. Accepts list with combination of "core", "content" and "other"
+            repo_types: The set of repos to use. Accepts list with combination of "core", "content" and "other"
             content_types: The set of content-types to use. Accepts combination of "guides", "learn" and "tutorial"
 
         Example:
@@ -94,7 +94,7 @@ class AgregationUtils:
 
         # Selected  a set of repos
         selected_repos = []
-        selected_content = content_types or ["tutorials", "guides", "learn"]
+        selected_content = content_types or ["tutorials", "guides", "learn", "reference"]
         if not repo_types:  # default case
             selected_repos = self.repos.all
         else:
@@ -108,7 +108,7 @@ class AgregationUtils:
                 )
                 _repo_content = self.get_children(lookup_path)
                 if _repo_content:
-                    _nav[repo.title] = _repo_content
+                    _nav[repo.title] = _repo_content if len(_repo_content) > 1 else _repo_content[0]
         # Expand content-types
         else:
             for repo in selected_repos:

--- a/staging_docs/dev/reference/markdown-cheatsheet.md
+++ b/staging_docs/dev/reference/markdown-cheatsheet.md
@@ -1,0 +1,153 @@
+# Markdown Cheatsheet
+
+There are basic markdown features recommended for use in Pulp.
+
+### Internal links
+
+=== "Template"
+
+    ```markdown
+    [My Link](site:{repo-name}/docs/{persona}/{content-type}/some-page.md).
+    ```
+
+=== "Sample"
+
+    ```markdown
+    [My Link](site:pulp-docs/docs/dev/reference/markdown-cheatsheet.md).
+    ```
+
+=== "Sample Rendered"
+
+    ```markdown
+    [My Link](http://127.0.0.1:8000/pulp-docs/docs/dev/reference/markdown-cheatsheet/).
+    ```
+
+- This is enabled by [mkdocs-site-urls](https://github.com/octoprint/mkdocs-site-urls) plugin.
+- This is preferred over *relative* links because of our complex structure. See tradeoffs [here](https://github.com/pedro-psb/pulp-docs/issues/2)
+
+
+### Codeblocks
+
+
+=== "Raw"
+
+    ````
+    ```
+    <location "/pulp/api/v3/foo_route">
+    proxypass /pulp/api http://${pulp-api}/pulp/api
+    proxypassreverse /pulp/api http://${pulp-api}/pulp/api
+    requestheader set foo "asdf"
+    </location>
+    ```
+    ````
+
+    ---
+
+    ```
+    <location "/pulp/api/v3/foo_route">
+    proxypass /pulp/api http://${pulp-api}/pulp/api
+    proxypassreverse /pulp/api http://${pulp-api}/pulp/api
+    requestheader set foo "asdf"
+    </location>
+    ```
+
+=== "Python Language"
+
+    ````
+    ```python
+    serializer = mymodelserializer(data=data)
+    serializer.is_valid(raise_exception=true)
+    instance = serializer.create(serializer.validated_data)
+    ```
+    ````
+
+    ---
+
+    ```python
+    serializer = mymodelserializer(data=data)
+    serializer.is_valid(raise_exception=true)
+    instance = serializer.create(serializer.validated_data)
+    ```
+
+=== "Python REPL"
+
+    ````
+    ```python
+    >>> serializer = mymodelserializer(data=data)
+    >>> serializer.is_valid(raise_exception=true)
+    >>> instance = serializer.create(serializer.validated_data)
+    Some output
+    ```
+    ````
+
+    ---
+
+    ```python
+    >>> serializer = mymodelserializer(data=data)
+    >>> serializer.is_valid(raise_exception=true)
+    >>> instance = serializer.create(serializer.validated_data)
+    Some output
+    ```
+
+=== "With 'Title'"
+
+    ````
+    ```bash title="script.sh"
+    pulp file repository update --name myrepo --retained-versions 1
+    ```
+    ````
+
+    ---
+
+    ```bash title="script.sh"
+    pulp file repository update --name myrepo --retained-versions 1
+    ```
+
+### Tabbed content
+
+
+<div class="grid" markdown>
+
+````
+=== "Run"
+
+    ```bash
+    cat myfile.txt
+    ```
+
+=== "Output"
+
+    ```bash
+    line1
+    line2
+    line3
+    ```
+````
+
+=== "Run"
+
+    ```bash
+    cat myfile.txt
+    ```
+
+=== "Output"
+
+    ```bash
+    line1
+    line2
+    line3
+    ```
+
+</div>
+
+- [See mkdocs-material](https://squidfunk.github.io/mkdocs-material/reference/content-tabs/#usage)
+- Each tab title must be in quotes
+- Each tab block must have 4 spaces of indent
+- Put space around `=== "Title"`
+
+### Admonitions
+
+[See mkdocs-material](https://squidfunk.github.io/mkdocs-material/reference/admonitions/#supported-types)
+
+Use them wisely.
+

--- a/staging_docs/rest_api.md
+++ b/staging_docs/rest_api.md
@@ -1,0 +1,11 @@
+# Rest API
+
+The REST API reference for Pulp Plugins is generated using [ReDoc](https://redocly.com/redoc/) and are published in standalone pages:
+
+<div class="grid cards" markdown>
+
+{% for repo in get_repos() %}
+- <a href="https://docs.pulpproject.org/{{ repo.name }}/restapi.html" target="_blank">{{ repo.title }}</a>
+{% endfor %}
+
+</div>

--- a/staging_docs/sections/admin/index.md
+++ b/staging_docs/sections/admin/index.md
@@ -1,0 +1,1 @@
+# Overview

--- a/staging_docs/sections/admin/index.md
+++ b/staging_docs/sections/admin/index.md
@@ -1,1 +1,49 @@
-# Overview
+---
+hide:
+  - toc
+---
+<div class="hero-header" markdown>
+<h1 class="landing-page-h1"></h1>
+
+## This section is for **admins**
+
+Common needs are to *configure, deploy and maintain Pulp instances*.
+
+
+
+<div class="grid cards" markdown>
+
+- **Build and deploy**
+
+    ---
+
+    Start developing your service or application by levaraging our powerfull deployment setups.
+    
+- **Engage**
+
+    ---
+
+    Get and provide feedback from the peers to help our Project and your Product to grow.
+
+</div>
+</div>
+
+---
+
+## Quick Links
+
+
+{% for repo_type in ("core", "content") %}
+Repo | Version | Rest API | Github Page | Changelog
+--- | --- | --- | --- | --- 
+{% for repo in get_repos(repo_type) -%}
+{{ repo.title }} | `{{ repo.version }}` | <a href="{{ repo.rest_api_url}}" target="_blank">:link:</a> | [:link:]({{ repo.codebase_url }}) | [:link:]({{ repo.changelog_url }})
+{% endfor %}
+{% endfor %}
+
+Repo | Version | Code (Github) | Changelog
+--- | --- | --- | --- 
+{% for repo in get_repos("other") -%}
+{{ repo.title }} | `{{ repo.version }}` | [:link:]({{ repo.codebase_url }}) | [:link:]({{ repo.changelog_url }})
+{% endfor %}
+

--- a/staging_docs/sections/dev/index.md
+++ b/staging_docs/sections/dev/index.md
@@ -1,0 +1,1 @@
+# Overview

--- a/staging_docs/sections/dev/index.md
+++ b/staging_docs/sections/dev/index.md
@@ -1,1 +1,51 @@
-# Overview
+---
+hide:
+  - toc
+---
+<div class="hero-header" markdown>
+<h1 class="landing-page-h1"></h1>
+
+## This section is for Pulp **developers**
+
+Common needs are to *improve docs, fix bugs and add features*.
+
+
+
+<div class="grid cards" markdown>
+
+-   **Contributing**
+
+    ---
+    
+    Learn the basic for contributing to Pulp: opening PRs, code style, releases cycles and versioning.
+
+    
+-   **Deep Dive**
+    
+    ---
+
+    Dive-in into Pulp code and architecture to help extend, improve and move the project foward.
+
+    
+</div>
+</div>
+
+---
+
+## Quick Links
+
+
+{% for repo_type in ("core", "content") %}
+Repo | Version | Rest API | Github Page | Changelog
+--- | --- | --- | --- | --- 
+{% for repo in get_repos(repo_type) -%}
+{{ repo.title }} | `{{ repo.version }}` | <a href="{{ repo.rest_api_url}}" target="_blank">:link:</a> | [:link:]({{ repo.codebase_url }}) | [:link:]({{ repo.changelog_url }})
+{% endfor %}
+{% endfor %}
+
+Repo | Version | Code (Github) | Changelog
+--- | --- | --- | --- 
+{% for repo in get_repos("other") -%}
+{{ repo.title }} | `{{ repo.version }}` | [:link:]({{ repo.codebase_url }}) | [:link:]({{ repo.changelog_url }})
+{% endfor %}
+

--- a/staging_docs/sections/help/community/00_get-involved.md
+++ b/staging_docs/sections/help/community/00_get-involved.md
@@ -1,0 +1,35 @@
+# Get involved
+
+A good way to get more help os reaching out to fellow Pulp users and developers.
+
+## Communication Channels
+
+Feel free to ask and answer questions, give feedback about your experience working with any aspect of Pulp.
+Introduce yourself, your project, what you’re hoping to achieve with Pulp. We would be delighted to hear from you and understand how Pulp is helping.
+
+- [Community Forum](https://discourse.pulpproject.org/) on Discourse.
+    - User Support, Development Discussions, Announcements and more
+- [Community Chat Space](https://app.element.io/#/room/#pulp-space:matrix.org) on Matrix.
+    - `pulp`: User Support
+    - `pulp-dev`: General Development Discussions
+    - `pulp-meeting`: Open Floor* and Bug Triage (every Tuesday at 10:30 ET)
+    - `pulp-{plugin}`: Plugin Specific Discussions
+
+!!! Note "*Open Floor"
+
+    Open Floor is a time for developer discussion, feedback, and decisions on code/issues/PRs/process relating to pulpcore or plugins. To participate, put a topic on the agenda.
+
+## Reporting
+
+- For reporting a **bug** or requesting a **feature**:
+    1. First try to search if some similar issue was not already reported.
+    2. If not, submit an issue to the appropriate repository (pulpcore, pulp_rpm, pulp-oci-images, etc)
+- For **security issue**, send an email to [pulp-security@redhat.com](#) with:
+    - Pulp version
+    - Vulnerability description
+    - Reproduction steps.
+
+## Helpful links
+
+- [Youtube channel](https://www.youtube.com/PulpProject): Demos, even recordings and rich discussions!
+- [Twitter](https://twitter.com/pulpproj): Release news

--- a/staging_docs/sections/help/community/01_pulpcon.md
+++ b/staging_docs/sections/help/community/01_pulpcon.md
@@ -1,0 +1,3 @@
+# PulpCon
+
+EDIT ME.

--- a/staging_docs/sections/help/governance/code-of-conduct.md
+++ b/staging_docs/sections/help/governance/code-of-conduct.md
@@ -1,0 +1,75 @@
+# Code of Conduct
+
+## Contributor Covenant Code of Conduct
+
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+### Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at pulp-conduct@redhat.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [`https://www.contributor-covenant.org/version/1/4/code-of-conduct.html`](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html)
+
+[homepage]: https://www.contributor-covenant.org

--- a/staging_docs/sections/help/governance/privacy.md
+++ b/staging_docs/sections/help/governance/privacy.md
@@ -1,0 +1,124 @@
+# Privacy Policy
+
+**Updated: April 14 2022**
+
+This privacy policy is a living document.
+
+You can find all information regarding the Pulp community's information practices and the choices you can make about the way your personal information is collected, used and disclosed.
+
+## The Information We Collect
+
+This Privacy Statement applies to all information collected by or submitted to the Pulp community ecosystem, including personal data. “Personal data” is data that can be used to identify an individual.
+
+Examples when  personal data is collected within the Pulp community include but are not limited to:
+   * you create an account on our forum
+   * you sign up to our mailing lists
+   * you contribute code
+   * you participate in surveys and evaluations
+   * you participate in giveaways
+   * you submit questions or comments to us
+
+
+## Our Website
+
+Our website uses Google Analytics but we have [anonymized](https://developers.google.com/analytics/devguides/collection/gajs/methods/gaJSApi_gat#_gat._anonymizeIp) IP addresses. We have active plans to move from Google Analytics to an open-source alternative in the near future.
+
+We do not use any linked Google product, e.g. AdWords.
+Google Analytics data is deleted after 26 months.
+
+The webserver logs and Google Analytics are used to produce aggregated statistics about the community, such as popularity of different web pages, so that we can create more relevant content for community members.
+
+The webserver (Apache) logs contain IP addresses, timestamps, and UserAgent strings - these are log-rotated weekly during the weekend, and all records are deleted after about one month.
+
+You are free to use a VPN, Tor, or other IP / UserAgent masking service without affecting your use of the project website, as it is entirely static.
+
+### Website videos
+
+The website embeds videos from [YouTube](https://support.google.com/youtube/answer/7671399?hl=en) and [FOSDEM](https://fosdem.org/2022/).
+
+**Legal basis for this data usage: Legitimate interest**
+
+## Our Codebase
+
+The Pulp community uses GitHub to manage the code that comprises the Pulp project. The Pulp community also uses GitHub for issue reporting and tracking. Refer to [GitHub’s privacy policy](https://docs.github.com/en/site-policy/privacy-policies/global-privacy-practices) for details on how GitHub handles the data you post there.
+
+Commit messages can contain names and email addresses. You are free to use pseudonymous data for commit messages. We do prefer a working contact mail in case of needing to contact contributors to the codebase, but it is not mandatory.
+
+**Legal basis for this data usage: Legitimate interest, consent**
+
+
+## Pulp Community Discourse
+
+The Pulp community centralizes all asynchronous communication on a self-hosted Discourse server.
+
+When signing up for a Discourse account, you provide a name and email address - and in addition we store the IP address of your most recent connection. The email address is only used to send you updates to your forum topics, personal messages from other users, and digest summaries. You have full control over the emails sent from your Discourse account preferences. The forum also uses cookies to store your session.
+
+Within Discourse, you can also to provide your name, location, profile picture and further publicly identifiable information in your Discourse profile, but this is opt-in, optional, and at your discretion. We have no requirement that you use your real name.
+
+We also use the IP addresses and public post data to provide aggregated statistics about the forum community, such as posts-per-month, user engagement, etc. We also use the IP addresses to help identify sock puppeting and spam accounts.
+
+Please refer to [Discourse's privacy policy](https://discourse.pulpproject.org/privacy) for further information.
+
+You are free to use a VPN, Tor, or other IP / UserAgent masking service without affecting your access to Pulp's community Discourse.
+
+**Legal basis for this data usage: Legitimate interest, consent**
+
+## Pulp Community Matrix
+
+We conduct all Pulp community synchronous communication via Matrix. We also have Libera.Chat IRC bridges from our Matrix room. If you use Libera.Chat IRC, you will need to register your IRC nick to be able to post messages in our channels or to direct message individuals. For more information see, [Matrix's privacy policy](https://matrix.org/legal/privacy-notice) and the [libera.chat's privacy policy](https://libera.chat/privacy/).
+
+## Third party links
+
+The Pulp community does not control the information collection of sites that can be reached through links shared throughout the communtiy. If you have questions about the data collection procedures of linked sites, please contact those sites directly.
+
+## Surveys & Forms
+
+The Pulp community runs a survey each year. Completing the survey is opt-in, and providing a contact email address in the survey is optional. Such addresses are stored until the survey analysis is complete, and then deleted from the raw survey data before publication. The survey data is used to gain understanding of the community.
+
+We also use forms to collect information to distribute SWAG to community contributors. This includes all the information relevant for distributing SWAG via a courier, including name, address, and phone number, clothing size etc. All of this is opt-in, optional, and your personal information is deleted from the form after distribution.
+
+
+**Legal basis for this data usage: Legitimate interest, consent**
+
+
+## Your choices
+
+You can choose not to provide us with personal data
+
+Using a VPN, Tor, or other IP / UserAgent masking service will not affect your use of the project website, as it is entirely static. For Discourse, we do not mandate use of real names, and using pseudonyms will not affect the services.
+
+## Your accounts on our services
+
+Your Discourse accounts contain options to control what emails are sent to you. 3rd party services such as GitHub retain their own policies and privacy options.
+
+## Your rights
+
+Where the EU General Data Protection Regulation 2016/679 (“GDPR”) applies to the processing of your personal data, especially when you access the website from a country in the European Economic Area (“EEA”), you have the following rights, subject to some limitations, against the Foreman Project:
+
+* The right to access your personal data
+* The right to rectify the personal data we hold about you
+* The right to erase your personal data
+* The right to restrict our use of your personal data
+* The right to object to our use of your personal data
+* The right to receive your personal data in a usable electronic format and transmit it to a third party (also known as the right of data portability)
+* The right to lodge a complaint with your local data protection authority
+
+If you would like to exercise any of these rights, you may do so by contacting the Pulp community at privacy@pulpproject.org. Please understand, however, the rights enumerated above are not absolute in all cases, especially in regards to the right to erase your data:
+
+**Git commits will not be rewritten**
+Contributing to Pulp codebase is opt-in.
+Providing personally identifying information in commit messages is a further opt-in.
+
+The Pulp community has a legitimate interest in contacting contributors and showing IP provenance
+
+**Forum posts will not be removed**
+
+Discourse data which is public (i.e forum posts, bug comments etc) will be pseudonymised.
+
+Your account name, handle, and email address will be scrambled, removing your personal data from the site
+
+Posts are not removed, as we have a legitimate interest in retaining the history of discussions about our project
+
+## How to Contact Us
+
+If you have any questions about any of these practices or the Pulp project’s use of your personal information, contact us by email at privacy@pulpproject.org

--- a/staging_docs/sections/help/index.md
+++ b/staging_docs/sections/help/index.md
@@ -1,1 +1,0 @@
-# Overview

--- a/staging_docs/sections/help/index.md
+++ b/staging_docs/sections/help/index.md
@@ -1,0 +1,1 @@
+# Overview

--- a/staging_docs/sections/help/using-this-doc/00-background.md
+++ b/staging_docs/sections/help/using-this-doc/00-background.md
@@ -1,0 +1,5 @@
+# Background Knowledge
+
+About Diataxis background, pulp repository types and pulp personas.
+
+EDITME

--- a/staging_docs/sections/help/using-this-doc/01-doc-anatomy.md
+++ b/staging_docs/sections/help/using-this-doc/01-doc-anatomy.md
@@ -1,0 +1,3 @@
+# The Anatomy of the Website
+
+EDITME

--- a/staging_docs/sections/help/using-this-doc/02-nav-and-search.md
+++ b/staging_docs/sections/help/using-this-doc/02-nav-and-search.md
@@ -1,0 +1,3 @@
+# Navigation and Search Tips
+
+EDITME

--- a/staging_docs/sections/reference/index.md
+++ b/staging_docs/sections/reference/index.md
@@ -1,0 +1,1 @@
+# Overview

--- a/staging_docs/sections/user/index.md
+++ b/staging_docs/sections/user/index.md
@@ -1,0 +1,60 @@
+---
+hide:
+  - toc
+---
+<div class="hero-header" markdown>
+# Overview
+
+## This section is for users who need to need create sync, publish and interact with repositories.
+
+
+
+<div class="grid cards" markdown>
+
+-   **Get Started**
+
+    ---
+    
+    Complete the started tutorial [here](#).
+
+    
+-   **Understand the docs**
+    
+    ---
+
+    Get familiar withhow to use this documentation works. [here](#)
+
+- **Explore**
+
+    ---
+
+    Some content
+
+- **Engage**
+
+    ---
+
+    Some content
+
+</div>
+</div>
+
+---
+
+## Quick Links
+
+
+{% for repo_type in ("core", "content") %}
+Repo | Version | Rest API | Github Page | Changelog
+--- | --- | --- | --- | --- 
+{% for repo in get_repos(repo_type) -%}
+{{ repo.title }} | `{{ repo.version }}` | <a href="{{ repo.rest_api_url}}" target="_blank">:link:</a> | [:link:]({{ repo.codebase_url }}) | [:link:]({{ repo.changelog_url }})
+{% endfor %}
+{% endfor %}
+
+Repo | Version | Code (Github) | Changelog
+--- | --- | --- | --- 
+{% for repo in get_repos("other") -%}
+{{ repo.title }} | `{{ repo.version }}` | [:link:]({{ repo.codebase_url }}) | [:link:]({{ repo.changelog_url }})
+{% endfor %}
+

--- a/staging_docs/sections/user/index.md
+++ b/staging_docs/sections/user/index.md
@@ -3,9 +3,12 @@ hide:
   - toc
 ---
 <div class="hero-header" markdown>
-# Overview
 
-## This section is for users who need to need create sync, publish and interact with repositories.
+<h1 class="landing-page-h1"></h1>
+
+## This section is for **users**
+
+Common needs are to *create, sync, publish and interact with repositories*.
 
 
 
@@ -15,26 +18,15 @@ hide:
 
     ---
     
-    Complete the started tutorial [here](#).
+    Complete the starter tutorial to learn in pratice the basics of managing content in Pulp.
 
     
 -   **Understand the docs**
     
     ---
 
-    Get familiar withhow to use this documentation works. [here](#)
-
-- **Explore**
-
-    ---
-
-    Some content
-
-- **Engage**
-
-    ---
-
-    Some content
+    Pulp has a rich ecosystem of plugins.
+    Understanding the docs can help you find information more efficiently.
 
 </div>
 </div>


### PR DESCRIPTION
## What this does

- Remove the "common" Reference section in favor or *persona-scoped* Reference (as everything else)
  - TLDR: use `staging_docs/{persona}/reference` instead of the global `staging_docs/reference`.
  - I've suggested a common reference before because I was unsure how reference could be persona-scoped. After seeing more real content, I'm convinced that we should scope them for both consistency and convenience.
- Re-organize Section overviews (user,admin,dev manuals)
  - Move responsibility for those from `pulpcore` to `pulp-docs`, because these "sections content" are highly coupled with the navigation that `pulp-docs` define.
  - Add some fancy tiles for most useful links/paths
  - Add "Quick Links" table (auto-generated) for each of them with version and links for rest-api, github and changelog. I've found myself wishing for this sometimes, and I hope it will be generally useful.
- Re-organize "Help" Section.
  - Move changelogs there. It is not *quite the right place*, but I guess its reasonable, as we have "Quick Links" table now. An alternative is move it to its own top-level section (as I've removed "Reference" from there, it has some  "space left").
  - Move "Get Involved", "Code of Conduct" and "Privacy Policy" from main Pulp site here. I've also re-written "Get Involved" so its more succint.
  - Add placeholder Tutorial (probably) called "Documentation Usage", for explaining the foundation concepts of the content organizations and the website structure and how to leverage them to find things.

## Screenshots

### Section Overviews

This is similar to *user* and *admin*.

![image](https://github.com/pedro-psb/pulp-docs/assets/7907864/b71ccf31-4941-4083-8e02-452b1367a890)

### Help Page

![image](https://github.com/pedro-psb/pulp-docs/assets/7907864/b4a47252-1056-47a9-bad3-13488e677e4b)
