### PR TITLE
Add workaround for mkdocstring source-find subpackages

### DIFF
--- a/src/pulp_docs/data/mkdocs.yml
+++ b/src/pulp_docs/data/mkdocs.yml
@@ -52,8 +52,8 @@ plugins:
             show_symbol_type_toc: true
             docstring_section_style: table # table, list, spacy
             # heading_level: 2
-            # show_root_heading: false
-            # show_root_toc_entry: false
+            show_root_heading: true
+            show_root_toc_entry: true
             show_if_no_docstring: false
             show_signature_annotations: false
             separate_signature: false

--- a/src/pulp_docs/data/repolist.yml
+++ b/src/pulp_docs/data/repolist.yml
@@ -65,10 +65,6 @@ repos:
       owner: pulp
       title: Pulp CLI
       branch: main
-    # - name: pulp_glue
-    #   nested_under: pulp/pulp-cli/pulp_glue
-    #   title: Pulp Glue
-    #   branch: main
     - name: pulp-openapi-generator
       owner: pulp
       title: OpenAPI Generator
@@ -77,3 +73,11 @@ repos:
       owner: pulp
       title: Selinux
       branch: main
+    - name: oci_env
+      owner: pulp
+      title: OCI Env
+      branch: main
+    # subpackages
+    - name: pulp-glue
+      title: Pulp Glue
+      subpackage_of: pulp-cli


### PR DESCRIPTION
This enables mkdocstrings to find:
- pulp-cli/pulp-glue/
- pulp-cli/pulpcore/

This should work also if those code-sources do not use explicit `__init__.py` to declare they are modules.

[noissue]