### PR TITLE
Update links, add brand color and fix title display

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Also, this should be used for the production build.
 
 Through a `mkdocs-macro-plugin` hook (called in early stages of mkdocs processing), we inject the following steps:
 
-1. Read [`repolist.yml`](https://github.com/pedro-psb/pulp-docs/blob/main/src/pulp_docs/data/repolist.yml) packaged with `pulp-docs` to know which repos/urls to use
+1. Read [`repolist.yml`](https://github.com/pulp/pulp-docs/blob/main/src/pulp_docs/data/repolist.yml) packaged with `pulp-docs` to know which repos/urls to use
 1. Download/Move all source code required to dir under `tempfile.gettempdir()`
     - Uses `../{repo}` if available OR
     - Uses existing cached `{tmpdir}/{repo}` if available OR
@@ -39,7 +39,7 @@ And thats it, the magic is done.
 Recommended way for daily usage:
 
 ```bash
-pipx install git+https://github.com/pedro-psb/pulp-docs --include-deps
+pipx install git+https://github.com/pulp/pulp-docs --include-deps
 pulp-docs serve
 ```
 

--- a/src/pulp_docs/data/mkdocs.yml
+++ b/src/pulp_docs/data/mkdocs.yml
@@ -6,7 +6,7 @@ repo_name: pulp/pulpcore
 docs_dir: docs
 theme:
   name: material
-  logo: pulp-docs/docs/assets/logo.png
+  logo: pulp-docs/docs/assets/pulp_logo_icon.svg
   favicon: pulp-docs/docs/assets/favicon.ico
   features:
     - content.code.annotate
@@ -25,7 +25,7 @@ theme:
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default
-      primary: indigo
+      primary: custom
       accent: black
       toggle:
         icon: material/toggle-switch-off-outline 

--- a/src/pulp_docs/data/repolist.yml
+++ b/src/pulp_docs/data/repolist.yml
@@ -54,8 +54,8 @@ repos:
       title: Pulp OCI Images
       branch: latest
     - name: pulp-docs
-      owner: pedro-psb
-      title: Docs Tool
+      owner: pulp
+      title: Pulp Docs
       branch: main
     - name: pulp-operator
       owner: pulp

--- a/src/pulp_docs/mkdocs_macros.py
+++ b/src/pulp_docs/mkdocs_macros.py
@@ -111,7 +111,7 @@ def prepare_repositories(TMPDIR: Path, repos: Repos, config: Config):
 
     # Copy core-files (shipped with pulp-docs) to tmpdir
     shutil.copy(
-        repo_sources / repos.core_repo.name / SRC_DOCS_DIRNAME / "index.md",
+        repo_sources / "pulp-docs" / SRC_DOCS_DIRNAME / "index.md",
         repo_docs / "index.md",
     )
 

--- a/staging_docs/assets/pulp_logo_icon.svg
+++ b/staging_docs/assets/pulp_logo_icon.svg
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="46.249287mm"
+   height="38.796974mm"
+   viewBox="0 0 163.87543 137.46959"
+   id="svg4179"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="pulp_logo_icon.svg">
+  <defs
+     id="defs4181" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="6.3213979"
+     inkscape:cx="81.937713"
+     inkscape:cy="68.734797"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:showpageshadow="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1043"
+     inkscape:window-x="3840"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata4184">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-85.73922,-1430.9315)">
+    <g
+       id="g4243"
+       transform="translate(-162.53017,1069.7224)"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90">
+      <path
+         sodipodi:nodetypes="scscs"
+         inkscape:connector-curvature="0"
+         id="path4245"
+         d="m 383.20655,396.36429 c -10.55376,8.96535 -25.43828,12.42625 -35.99006,11.10505 0.84945,-6.86243 6.3978,-24.04396 17.24056,-33.1762 10.59473,-8.9233 29.20367,-14.6293 36.97027,-12.71365 1.98655,10.78842 -7.66683,25.81927 -18.22077,34.7848 z"
+         style="opacity:1;fill:#04ae19;fill-opacity:1;stroke:none;stroke-width:4.40485716;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <g
+         transform="matrix(0.92204773,0,0,0.92204773,-554.11752,-1234.7469)"
+         id="g4247"
+         style="fill:#04ae19;fill-opacity:1;stroke:none">
+        <path
+           sodipodi:nodetypes="scscs"
+           inkscape:connector-curvature="0"
+           id="path4249"
+           d="m 959.85401,1770.4306 c 4.5637,6.2171 12.18287,10.0092 18.07028,10.6524 0.42358,-3.8278 -0.36983,-13.8518 -5.06864,-20.1965 -4.59133,-6.1993 -13.93929,-11.6878 -18.39418,-11.6502 -2.46584,5.5898 0.82883,14.9773 5.39254,21.1943 z"
+           style="opacity:1;fill:#04ae19;fill-opacity:1;stroke:none;stroke-width:4.40485716;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      </g>
+      <path
+         inkscape:connector-curvature="0"
+         id="path4251"
+         d="m 330.20774,416.25032 c -45.16376,0 -81.93835,36.7746 -81.93835,81.93833 0,0.16361 0.008,0.32604 0.008,0.48942 l 15.04819,0 c 0,-0.16338 -0.008,-0.32575 -0.008,-0.48942 0,-37.03108 29.85907,-66.89012 66.89016,-66.89012 37.0311,0 66.8888,29.85904 66.8888,66.89012 0,0.16367 -0.008,0.32604 -0.008,0.48942 l 15.04827,0 c 6.5e-4,-0.16338 0.008,-0.32581 0.008,-0.48942 0,-45.16373 -36.77331,-81.93833 -81.93707,-81.93833 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#347dbe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:23;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <path
+         style="opacity:1;fill:#ff9507;fill-opacity:1;stroke:none;stroke-width:23;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 246.85156,194.8125 a 56.014499,56.014499 0 0 0 -39.24414,16.11523 l 43.30664,27.83594 5.53125,-3.23047 0,-39.89062 a 56.014499,56.014499 0 0 0 -9.59375,-0.83008 z m 19.07813,3.40234 0,35.81836 7.83789,4.47266 21.35547,-15.97852 a 56.014499,56.014499 0 0 0 -29.19336,-24.3125 z m -64.53125,19.9961 a 56.014499,56.014499 0 0 0 -10.5625,32.61523 56.014499,56.014499 0 0 0 0.041,1.14649 l 56.14453,0 -0.0234,-4.46875 a 4.7433303,4.7433303 0 0 1 -0.35938,-0.21094 l -45.24023,-29.08203 z m 97.87109,13.06054 -21.25391,15.9004 0.0254,4.80078 24.76757,0 a 56.014499,56.014499 0 0 0 0.0586,-1.14649 56.014499,56.014499 0 0 0 -3.59766,-19.55469 z"
+         transform="translate(83.355629,246.70606)"
+         id="path4253"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/staging_docs/css/extra.css
+++ b/staging_docs/css/extra.css
@@ -29,7 +29,13 @@
     text-align: center;
     margin-inline: auto;
 }
+.hide-h1 {
+    position: absolute;
+    left: -999px
+}
 
-.landing-page-h1 {
-    display: None;
+:root {
+  --md-primary-fg-color:        #347dbe;
+  --md-primary-fg-color--light: #ECB7B7;
+  --md-primary-fg-color--dark:  #90030C;/
 }

--- a/staging_docs/dev/index.md
+++ b/staging_docs/dev/index.md
@@ -13,7 +13,7 @@ It was developed as part of [The new Pulp "Unified Docs"](https://hackmd.io/eE3k
 
 Through a `mkdocs-macro-plugin` hook (called in early stages of mkdocs processing), we inject the following steps:
 
-1. Read [`repolist.yml`](https://github.com/pedro-psb/pulp-docs/blob/main/src/pulp_docs/data/repolist.yml) packaged with `pulp-docs` to know which repos/urls to use
+1. Read [`repolist.yml`](https://github.com/pulp/pulp-docs/blob/main/src/pulp_docs/data/repolist.yml) packaged with `pulp-docs` to know which repos/urls to use
 1. Download and Place all source code required to dir under `tempfile.gettempdir()`
     - Uses `../{repo}` if available OR
     - Uses existing cached `{tmpdir}/{repo}` if available OR
@@ -27,13 +27,13 @@ Recommended way for daily usage:
 === "pipx"
 
     ```bash
-    pipx install git+https://github.com/pedro-psb/pulp-docs --include-deps
+    pipx install git+https://github.com/pulp/pulp-docs --include-deps
     pulp-docs serve
     ```
 
 === "pip"
 
     ```bash
-    pip --user install git+https://github.com/pedro-psb/pulp-docs
+    pip --user install git+https://github.com/pulp/pulp-docs
     pulp-docs serve
     ```

--- a/staging_docs/dev/reference/markdown-cheatsheet.md
+++ b/staging_docs/dev/reference/markdown-cheatsheet.md
@@ -23,7 +23,7 @@ There are basic markdown features recommended for use in Pulp.
     ```
 
 - This is enabled by [mkdocs-site-urls](https://github.com/octoprint/mkdocs-site-urls) plugin.
-- This is preferred over *relative* links because of our complex structure. See tradeoffs [here](https://github.com/pedro-psb/pulp-docs/issues/2)
+- This is preferred over *relative* links because of our complex structure. See tradeoffs [here](https://github.com/pulp/pulp-docs/issues/2)
 
 
 ### Codeblocks

--- a/staging_docs/index.md
+++ b/staging_docs/index.md
@@ -1,0 +1,53 @@
+---
+hide:
+  - navigation
+  - toc
+  - footer
+---
+
+# Home {.hide-h1}
+<div class="hero-header" markdown>
+
+![Pulp Logo](site:pulpcore/docs/assets/pulp_logo_big.png)
+
+## Pulp is an open source project that makes it easy for developers to fetch, upload, and distribute *Software Packages* on-prem or in the cloud. {: #pulp-project}
+
+</div>
+
+---
+
+<div class="grid cards" markdown>
+
+-   :material-clock-fast:{ .lg .middle } **Starter Tutorial**
+
+    ---
+
+    Learn to manage content with Pulp and get yourself familiar with core concepts and workflows.
+
+    [:octicons-arrow-right-24: Getting started](site:pulpcore/docs/user/tutorials/01-overview/)
+
+-   :octicons-download-16:{ .lg .middle } **Pulp in a Container**
+
+    ---
+
+    Use OCI (Open Container Initiative) images to install Pulp in single or multi-container setups.
+
+    [:octicons-arrow-right-24: Installation Quickstart](site:pulp-oci-images/docs/admin/tutorials/quickstart/)
+
+-   :octicons-rocket-16:{ .lg .middle } **Why Pulp?**
+
+    ---
+
+    Learn why important projects rely on Pulp to manage the lifecyle of huge *Software Content* collections.
+
+    [:octicons-arrow-right-24: Features](#)
+
+-   :octicons-people-16:{ .lg .middle } **Get Involved**
+
+    ---
+
+    Join our communication channels and get to know the contributors and users of Pulp's strong ecosystem.
+
+    [:octicons-arrow-right-24: Community](#)
+
+</div>

--- a/staging_docs/sections/admin/index.md
+++ b/staging_docs/sections/admin/index.md
@@ -2,8 +2,10 @@
 hide:
   - toc
 ---
+
+# Admin Guide {.hide-h1}
+
 <div class="hero-header" markdown>
-<h1 class="landing-page-h1"></h1>
 
 ## This section is for **admins**
 

--- a/staging_docs/sections/dev/index.md
+++ b/staging_docs/sections/dev/index.md
@@ -2,8 +2,10 @@
 hide:
   - toc
 ---
+
+# Developer Guide {.hide-h1}
+
 <div class="hero-header" markdown>
-<h1 class="landing-page-h1"></h1>
 
 ## This section is for Pulp **developers**
 

--- a/staging_docs/sections/user/index.md
+++ b/staging_docs/sections/user/index.md
@@ -2,9 +2,10 @@
 hide:
   - toc
 ---
-<div class="hero-header" markdown>
 
-<h1 class="landing-page-h1"></h1>
+# User Guide {.hide-h1}
+
+<div class="hero-header" markdown>
 
 ## This section is for **users**
 


### PR DESCRIPTION
What this does:
- Move the main index from `pulpcore` to `pulp-docs`. **Every top section page is now "owned" by pulp-docs.**
- Update repository owner reference from `pedro-psb` to `pulp`
- Update primary color with Pulp's blue: `#347dbe`
- Fix "Pulp Project" title display, which was broken as a side-effect of a CSS trick to hide h1 title on section pages. Now we are using a different trick.
- Replace header logo with SVG version without pulp written on it

Closes #22