### PR TITLE
Add auto hot-reload and mkdocs options

### DIFF
--- a/src/pulp_docs/data/mkdocs.yml
+++ b/src/pulp_docs/data/mkdocs.yml
@@ -36,6 +36,8 @@ theme:
         icon: material/toggle-switch
         name: Switch to light mode    
 
+hooks:
+  - '../mkdocs_hooks.py'
 plugins:
   - search
   - site-urls

--- a/src/pulp_docs/mkdocs_hooks.py
+++ b/src/pulp_docs/mkdocs_hooks.py
@@ -1,0 +1,18 @@
+"""
+Hooks for mkdocs events.
+
+See: https://www.mkdocs.org/user-guide/configuration/#hooks
+"""
+
+
+def on_serve(server, config, builder):
+    """
+    Hook to unwatch the temp dirs.
+
+    See: https://www.mkdocs.org/dev-guide/plugins/#on_serve
+    """
+    tmpdir = config["docs_dir"]
+    mkdocs_yml = config["config_file_path"]
+    server.unwatch(tmpdir)
+    server.unwatch(mkdocs_yml)
+    return server

--- a/src/pulp_docs/mkdocs_macros.py
+++ b/src/pulp_docs/mkdocs_macros.py
@@ -273,7 +273,11 @@ def define_env(env):
     # Workaround for making "pulpcore/cli/common" from pulp-cli be available as:
     # '::: pulpcore.cli.common' (from any markdown)
     # This should be a general solution.
-    shutil.copytree(source_dir / "pulp-cli/pulpcore", source_dir / "pulpcore/pulpcore", dirs_exist_ok=True)
+    shutil.copytree(
+        source_dir / "pulp-cli/pulpcore",
+        source_dir / "pulpcore/pulpcore",
+        dirs_exist_ok=True,
+    )
     Path(source_dir / "pulpcore/pulpcore/cli/__init__.py").touch(exist_ok=True)
     Path(source_dir / "pulpcore/pulpcore/cli/common/__init__.py").touch(exist_ok=True)
 
@@ -286,6 +290,12 @@ def define_env(env):
     env.conf["docs_dir"] = docs_dir
     env.conf["nav"] = get_navigation(docs_dir, repos)
 
+    # Try to watch CWD/staging_docs
+    watched_workdir = Path("staging_docs")
+    if watched_workdir.exists():
+        env.conf["watch"].append(str(watched_workdir.resolve()))
+
+    # Pass relevant data for future processing
     log.info("[pulp-docs] Done with pulp-docs.")
     env.conf["pulp_repos"] = repos
     env.config["pulp_repos"] = repos


### PR DESCRIPTION
What this does:
- Add automatic hot-reload for changes under `$PWD/staging_docs` (if such folder exists)
- Pass `--watch` and `--no-livereload` flags to mkdocs

ps: no so "hot", as it takes several seconds :sweat_smile: But that's a different issue

Closes #9