### PR TITLE
Add lowerbound for mkdocstrings-python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pulp-docs"
 version = "0.0.1"
 dependencies = [
     "mkdocs-material",
-    "mkdocstrings[python]",
+    "mkdocstrings[python]>=1.9.1",
     "mkdocs-macros-plugin",
     "mkdocs-site-urls",
     "importlib_resources",


### PR DESCRIPTION
The 1.9.1 lowerbound ships with a essential fix for building the docs on pulpcore CI.

See: https://github.com/pulp/pulp-docs/issues/28

[noissue]