### PR TITLE
Fix mkdocstrings-python pinning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ name = "pulp-docs"
 version = "0.0.1"
 dependencies = [
     "mkdocs-material",
-    "mkdocstrings[python]>=1.9.1",
+    "mkdocstrings",
+    "mkdocstrings-python>=1.9.1",
     "mkdocs-macros-plugin",
     "mkdocs-site-urls",
     "importlib_resources",


### PR DESCRIPTION
The previous PR pinned `mkdostrings[python]>=1.9.1`, which was effectively pinning mkdocstrings, not mkdocstrings-python.