### PR TITLE
Integrate Redoc REST API to mkdocs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "mkdocs-macros-plugin",
     "mkdocs-site-urls",
     "mkdocs-literate-nav",
+    "bs4",
     "importlib_resources",
     "httpx",
     "rich",

--- a/src/pulp_docs/mkdocs_hooks.py
+++ b/src/pulp_docs/mkdocs_hooks.py
@@ -3,6 +3,7 @@ Hooks for mkdocs events.
 
 See: https://www.mkdocs.org/user-guide/configuration/#hooks
 """
+from bs4 import BeautifulSoup as bs
 
 
 def on_serve(server, config, builder):
@@ -16,3 +17,43 @@ def on_serve(server, config, builder):
     server.unwatch(tmpdir)
     server.unwatch(mkdocs_yml)
     return server
+
+
+REDOC_HEADER = """
+<link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+<style>
+  body {
+    margin: 0;
+    padding: 0;
+  }
+</style>
+"""
+
+REDOC_TAG_TEMPLATE = """
+<redoc spec-url='%s'></redoc>
+"""
+
+REDOC_SCRIPT = """
+<script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+"""
+
+
+def on_post_page(output, page, config):
+    if basepath := page.meta.get("restapi_json_file"):
+        redoc_tag = REDOC_TAG_TEMPLATE % basepath
+        bs_page = bs(output, "html.parser")
+
+        # Append <head>scripts
+        bs_page.html.head.append(bs(REDOC_HEADER, "html.parser"))
+
+        # Replace main content-container with <redoc> tag
+        main_container = bs_page.find_all("div", class_="md-main__inner")[0]
+        main_container.replace_with(bs(redoc_tag, "html.parser"))
+
+        # Append <script> tag at the end of body
+        bs_page.html.body.append(bs(REDOC_SCRIPT, "html.parser"))
+
+        # Remove footer (looks weird)
+        footer = bs_page.find_all(class_="md-footer")[0]
+        footer.decompose()
+        return str(bs_page)

--- a/src/pulp_docs/navigation.py
+++ b/src/pulp_docs/navigation.py
@@ -77,13 +77,6 @@ def grouped_by_persona(tmpdir: Path, repos: Repos):
         {"Overview": f"{SECTION_HOST}/docs/sections/help/index.md"},
         {"Community": f"{SECTION_HOST}/docs/sections/help/community/"},
         {"More": f"{SECTION_HOST}/docs/sections/help/more/"},
-        {
-            "Changelogs": [
-                {"Core": f.changes_grouping(CHANGES_PATH, repo_types=["core"])},
-                {"Plugins": f.changes_grouping(CHANGES_PATH, repo_types=["content"])},
-                {"Extra": f.changes_grouping(CHANGES_PATH, repo_types=["other"])},
-            ]
-        },
     ]
 
     # Main Section

--- a/src/pulp_docs/repository.py
+++ b/src/pulp_docs/repository.py
@@ -6,6 +6,7 @@ Their purpose is to facilitate declaring and downloading the source-code.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import shutil
@@ -13,7 +14,6 @@ import subprocess
 import tarfile
 import tempfile
 import typing as t
-from collections import ChainMap, defaultdict
 from dataclasses import dataclass, field
 from io import BytesIO
 from pathlib import Path
@@ -116,13 +116,13 @@ class Repo:
         # from remote
         elif not cached_repo.exists():
             log_header = "Downloading from remote"
+            src_copy_path = DOWNLOAD_CACHE_DIR / self.name
             download_from = download_from_gh_main(
-                DOWNLOAD_CACHE_DIR / self.name,
+                src_copy_path,
                 self.owner,
                 self.name,
                 self.branch_in_use,
             )
-            src_copy_path = DOWNLOAD_CACHE_DIR / self.name
 
         # copy from source/cache to pulp-docs workdir
         log.info(f"{log_header}: source={download_from}, copied_from={src_copy_path}")
@@ -133,6 +133,7 @@ class Repo:
             src_copy_path,
             dest_dir,
             ignore=shutil.ignore_patterns(*ignore_patterns),
+            dirs_exist_ok=True,
         )
 
         self.status.download_source = str(download_from)

--- a/src/pulp_docs/utils/aggregation.py
+++ b/src/pulp_docs/utils/aggregation.py
@@ -85,17 +85,26 @@ class AgregationUtils:
             if index_path.exists():
                 repo_nav.append({"Overview": str(index_path.relative_to(self.tmpdir))})
 
+            # Add content type for a repo (guides,tutorials,etc)
             for content_type in selected_content:
-                # Get repo files from content-type and persona
                 lookup_path = self._parse_template_str(
                     template_str, repo.name, content_type
                 )
                 _repo_content = self._add_literate_nav_dir(lookup_path)
 
-                # Prevent rendering content-type section if there are no files
-                if _repo_content:
+                if _repo_content:  # No content section if there are no files
                     content_type_title = Names.get(content_type)
                     repo_nav.append({content_type_title: _repo_content})  # type: ignore
+
+            # Add changelog and restapi
+            if "/user/" in template_str:
+                CHANGES_PATH = f"{repo.name}/changes.md"
+                RESTAPI_PATH = f"{repo.name}/restapi.md"
+                if repo.type in ("content", "core"):
+                    repo_nav.append({"REST API": RESTAPI_PATH})
+                repo_nav.append({"Changelog": CHANGES_PATH})
+
+            # Add navigation to Repo, if one exsits
             if repo_nav:
                 group_nav.append({repo.title: repo_nav})
         return group_nav or ["#"]
@@ -158,4 +167,3 @@ class AgregationUtils:
             kwargs["content"] = content_type
 
         return self.tmpdir / template_str.format(**kwargs)
-

--- a/staging_docs/sections/help/index.md
+++ b/staging_docs/sections/help/index.md
@@ -11,18 +11,18 @@ Don't hesistate to contact us!
 
 ---
 
-## Quick Links
+## Quick Links (WIP)
 
 {% for repo_type in ("core", "content") %}
-Repo | Version | Rest API | Github Page | Changelog
---- | --- | --- | --- | --- 
+Repo | Version | Links | &nbsp; | &nbsp;
+--- | --- | --- | --- | ---
 {% for repo in get_repos(repo_type) -%}
-{{ repo.title }} | `{{ repo.version }}` | <a href="{{ repo.rest_api_url}}" target="_blank">:link:</a> | [:link:]({{ repo.codebase_url }}) | [:link:]({{ repo.changelog_url }})
+{{ repo.title }} | `{{ repo.version }}` | {{ repo.restapi_link }} | {{ repo.codebase_link }} | {{ repo.changes_link }}
 {% endfor %}
 {% endfor %}
 
-Repo | Version | Code (Github) | Changelog
---- | --- | --- | --- 
+Repo | Version | Links | &nbsp;
+--- | --- | --- | ---
 {% for repo in get_repos("other") -%}
-{{ repo.title }} | `{{ repo.version }}` | [:link:]({{ repo.codebase_url }}) | [:link:]({{ repo.changelog_url }})
+{{ repo.title }} | `{{ repo.version }}` | {{ repo.codebase_link }} | {{ repo.changes_link }}
 {% endfor %}


### PR DESCRIPTION
The mkdocs plugins I've tried for openapi-schema display ([example](https://github.com/pulp/pulp-docs/pull/43)) don't support anchoring the endpoint links, which is something we do all the time.

Because of that, I've decided to bake a simple solution based on what we did with sphinx, with a small bonus of keeping mkdocs top header.

This does:
- Download `api.json` from `https://docs.pulpproject.org/{plugin}/api.json`
- Inject Redoc scripts into HTML api page. Uses the "on_post_page" mkdocs hook
- Change navigation:
  * Add "UserManual/{plugin}/restapi/"
  * Move CHANGES.md nav to "UserManual/{plugin}/changes/"
- Fix "Help#quick-links" table links

Known limitation:
- No dark-mode theme support. But I'm pretty sure there is some Redoc dark theme out there which we can use.
- Search doesnt work w/ endpoints, because its JS stuff. But I have a simple idea that may get around that.
- For now getting `api.json` from `https://docs.pulpproject.org/{plugin}/api.json` works, but this should break soon.

## Screenshots

### REST API

![image](https://github.com/pulp/pulp-docs/assets/7907864/09f3a612-b391-4cc0-b5ee-b3423515baac)


### Changelog

![image](https://github.com/pulp/pulp-docs/assets/7907864/5c2ea05b-524c-4916-b07d-5cd9016ce4d8)
