### PR TITLE
Feat/add toc indexes for plugins

### DIFF
--- a/src/pulp_docs/mkdocs_hooks.py
+++ b/src/pulp_docs/mkdocs_hooks.py
@@ -3,7 +3,77 @@ Hooks for mkdocs events.
 
 See: https://www.mkdocs.org/user-guide/configuration/#hooks
 """
+import re
+from collections import defaultdict
+from typing import Union
+
 from bs4 import BeautifulSoup as bs
+from mkdocs.structure.nav import Page, Section
+
+from pulp_docs.utils.toc import SectionToc
+
+# TODO: this should be more generalized for section pages
+section_pattern = re.compile(r"([a-z-_]+)/index.md")
+dev_section_pattern = re.compile(r"([a-z-_]+)/docs/dev/index.md")
+
+toc_pages: dict[str, dict[str, SectionToc]] = {
+    "User Manual": defaultdict(),
+    "Developer Manual": defaultdict(),
+}
+dev_toc_pages: dict[str, SectionToc] = {}
+
+TOC_PAGE_CSS = """
+<style>
+  .md-typeset ul {
+    line-height: 1.1;
+  }
+</style>
+"""
+
+
+def get_index_page_from(section: Section) -> Page:
+    for item in section.children:
+        if isinstance(item, Page) and "index.md" in item.file.src_uri:
+            return item
+    raise RuntimeError(f"Couldnt find index page for {section.title}.")
+
+
+def on_nav(nav, config, files):
+    """
+    Create repo-index-toc data here.
+    See hook events: https://www.mkdocs.org/dev-guide/plugins/#events
+    """
+    for section_name in ["User Manual", "Developer Manual"]:
+        # Get a flat list of plugin Section from for '{Type} Manual'
+        user_section = [s for s in nav.items if s.title == section_name][0]
+        user_subsections = [s for s in user_section.children if s.is_section]
+        user_plugins = [
+            s for type_section in user_subsections for s in type_section.children
+        ]
+
+        # Create and save each plugin section toc as SectionToc
+        for section in user_plugins:
+            plugin_page = get_index_page_from(section)
+            plugin_name = plugin_page.url.split("/")[0]
+            toc = SectionToc(section, config).process(ignore_page=plugin_page)
+            toc_pages[section_name][plugin_name] = toc
+
+
+def on_page_markdown(markdown, page: Page, config, files):
+    plugin_toc = None
+
+    if match := section_pattern.match(page.file.src_uri):
+        plugin_name = match.groups()[0]
+        plugin_toc = toc_pages["User Manual"].get(plugin_name, None)
+
+    if match := dev_section_pattern.match(page.file.src_uri):
+        plugin_name = match.groups()[0]
+        plugin_toc = toc_pages["Developer Manual"].get(plugin_name, None)
+
+    if plugin_toc and len(plugin_toc) > 0:
+        markdown += TOC_PAGE_CSS + "\n\n---\n\n## Summary\n\n" + plugin_toc.dumps()
+
+    return markdown
 
 
 def on_serve(server, config, builder):

--- a/src/pulp_docs/mkdocs_macros.py
+++ b/src/pulp_docs/mkdocs_macros.py
@@ -20,6 +20,7 @@ import logging
 import shutil
 import tempfile
 import time
+from contextlib import suppress
 from pathlib import Path
 from textwrap import dedent
 
@@ -27,8 +28,8 @@ import httpx
 import rich
 
 from pulp_docs.cli import Config
-from pulp_docs.navigation import get_navigation
 from pulp_docs.constants import SECTION_REPO
+from pulp_docs.navigation import get_navigation
 from pulp_docs.repository import Repo, Repos, SubPackage
 from pulp_docs.utils.general import get_git_ignored_files
 
@@ -190,6 +191,15 @@ def _place_doc_files(src_dir: Path, docs_dir: Path, repo: Repo, api_src_dir: Pat
     except FileNotFoundError:
         Path(docs_dir / "docs").mkdir(parents=True)
         repo.status.has_staging_docs = False
+
+    # Add index pages to User and Dev sections
+    for index_file in (docs_dir / "index.md", docs_dir / "docs/dev/index.md"):
+        with suppress(FileNotFoundError):
+            if not index_file.exists():
+                index_file.write_text(
+                    f"# Welcome to {repo.title}\n\nThis is a generated page. "
+                    "See [pulp-docs tricks](#) to learn how to add a custom intro page."
+                )
 
     # Setup section pages (for better urls)
     if repo.name == SECTION_REPO:

--- a/src/pulp_docs/mkdocs_macros.py
+++ b/src/pulp_docs/mkdocs_macros.py
@@ -198,7 +198,8 @@ def _place_doc_files(src_dir: Path, docs_dir: Path, repo: Repo, api_src_dir: Pat
             if not index_file.exists():
                 index_file.write_text(
                     f"# Welcome to {repo.title}\n\nThis is a generated page. "
-                    "See [pulp-docs tricks](#) to learn how to add a custom intro page."
+                    "See how to add a custom overview page for you plugin "
+                    "[here](site:pulp-docs/docs/dev/guides/create-plugin-overviews/)."
                 )
 
     # Setup section pages (for better urls)

--- a/src/pulp_docs/utils/aggregation.py
+++ b/src/pulp_docs/utils/aggregation.py
@@ -132,9 +132,11 @@ class AgregationUtils:
                 if "dev" not in selected_personas:
                     CHANGES_PATH = f"{repo.name}/changes.md"
                     RESTAPI_PATH = f"{repo.name}/restapi.md"
+                    PLUGIN_INDEX = f"{repo.name}/index.md"
                     if repo.type in ("content", "core"):
                         repo_nav.append({"REST API": RESTAPI_PATH})
                     repo_nav.append({"Changelog": CHANGES_PATH})
+                    repo_nav.append(PLUGIN_INDEX)
 
                 # Add navigation to Repo, if one exsits
                 if repo_nav:

--- a/src/pulp_docs/utils/toc.py
+++ b/src/pulp_docs/utils/toc.py
@@ -1,0 +1,51 @@
+from typing import Optional, Union
+
+from mkdocs.structure.nav import Page, Section
+
+
+class SectionToc:
+    def __init__(self, section: Section, config):
+        self._section = section
+        self._config = config
+        self._lines: list[str] = []
+
+    def process(self, ignore_page: Optional[Page] = None):
+        """Generate markdown lines from section data."""
+
+        def indent_write(obj, depth: int):
+            if obj == ignore_page:
+                return
+
+            self._add_item(obj, depth)
+            if isinstance(obj, Section):
+                for item in obj.children:
+                    indent_write(item, depth + 1)
+
+        for sub_section in self._section.children:
+            indent_write(sub_section, 0)
+        return self
+
+    def _add_item(self, item: Union[Section, Page], depth: int):
+        """Convert and store Section/Page as markdown (str) list entry."""
+        if isinstance(item, Page):
+            item.read_source(self._config)
+        title = item.title
+        if url := getattr(item, "url", ""):
+            toc_entry = "[{title}](site:{url})".format(title=title, url=url)
+        else:
+            toc_entry = "[{title}](#)".format(title=title)
+
+        space = "    " * depth
+        line = "{space}* {toc_entry}".format(space=space, toc_entry=toc_entry)
+        self._lines.append(line)
+
+    def dump(self, fd) -> None:
+        """Dump the ToC content o file."""
+        ...
+
+    def dumps(self) -> str:
+        """Dump the ToC as string."""
+        return "\n".join(self._lines)
+
+    def __len__(self):
+        return len(self._lines)

--- a/staging_docs/dev/guides/create-plugin-overviews.md
+++ b/staging_docs/dev/guides/create-plugin-overviews.md
@@ -1,0 +1,34 @@
+# Create plugin Overview Pages
+
+There are two plugin overview pages:
+
+- One for "User Manual" (e.g, `User Manual > Plugins > RPM`)
+- One for "Developer Manual" (e.g, `Developer Manual > Plugins > RPM`)
+
+These pages contains an introductory text for its target audicence and a generated ToC.
+Also, note that:
+
+- If no custom overview page is found, one will be generated.
+- A ToC will always be appended this file, even if you provide a custom page.
+
+## Create plugin overviews
+
+Create files named `index.md` in the appropriate directories.
+
+```bash
+# "User Manual" Overview
+touch docs/index.md
+
+# "Dev Manual" Overview
+touch docs/dev/index.md
+```
+
+## Writing style tips
+
+Things to keep in mind:
+
+- **Audience:** Target newcomers. Experienced users will probably use the ToC or the search.
+- **Format:** Synopsis + Roadmap. Tell what your plugin is, what it does and a simple roadmap for starting.
+- **Size:** Keep it brief. This should an easy win for the user before he starts this journey.
+
+

--- a/staging_docs/dev/index.md
+++ b/staging_docs/dev/index.md
@@ -1,39 +1,11 @@
 # Overview
 
-## What it is
+Pulp-Docs is a tool for serving and building the Pulp Project documentation
+(see [The new Pulp "Unified Docs"](https://hackmd.io/eE3kG8qhT9eohRYbtooNww?view)).
 
-`pulp-docs` is a tool for serving and building an unified doc out of Pulp's Plugin Ecosystem.
+The idea is that after installing `pulp-docs`, you'll imediatelly be able run the unified website and preview local changes as they will appear in this site.
+Also, this is used for the production build.
 
-The idea is that each repository should install `pulp-docs` and imediatelly be able run the unified website server.
-Also, this should be used for the production build.
+To start using it, see the [Getting Started](site:pulp-docs/docs/dev/tutorials/getting-started/) section.
+Before contributing, we recommend reading about the [Architecture](site:pulp-docs/docs/dev/reference/architecture/).
 
-It was developed as part of [The new Pulp "Unified Docs"](https://hackmd.io/eE3kG8qhT9eohRYbtooNww?view) project.
-
-## How it works
-
-Through a `mkdocs-macro-plugin` hook (called in early stages of mkdocs processing), we inject the following steps:
-
-1. Read [`repolist.yml`](https://github.com/pulp/pulp-docs/blob/main/src/pulp_docs/data/repolist.yml) packaged with `pulp-docs` to know which repos/urls to use
-1. Download and Place all source code required to dir under `tempfile.gettempdir()`
-    - Uses `../{repo}` if available OR
-    - Uses existing cached `{tmpdir}/{repo}` if available OR
-    - Downloads from github
-1. Configure `mkdocs` through a hook: fix `mkdocstrings` config, generate navigation structure, etc
-
-## Quickstart
-
-Recommended way for daily usage:
-
-=== "pipx"
-
-    ```bash
-    pipx install git+https://github.com/pulp/pulp-docs --include-deps
-    pulp-docs serve
-    ```
-
-=== "pip"
-
-    ```bash
-    pip --user install git+https://github.com/pulp/pulp-docs
-    pulp-docs serve
-    ```

--- a/staging_docs/dev/reference/architecture.md
+++ b/staging_docs/dev/reference/architecture.md
@@ -1,0 +1,15 @@
+# Architecture
+
+In general, pulp-docs is a wrapper around mkdocs and use its hooks to get things working together.
+It also leverages some plugins from the `mkdocs` ecosystem.
+
+## How it works
+
+Through a `mkdocs-macro-plugin` hook (called in early stages of mkdocs processing), we inject the following steps:
+
+1. Read [`repolist.yml`](https://github.com/pulp/pulp-docs/blob/main/src/pulp_docs/data/repolist.yml) packaged with `pulp-docs` to know which repos/urls to use
+1. Download and Place all source code required to dir under `tempfile.gettempdir()`
+    - Uses `../{repo}` if available OR
+    - Uses existing cached `{tmpdir}/{repo}` if available OR
+    - Downloads from github
+1. Configure `mkdocs` through a hook: fix `mkdocstrings` config, generate navigation structure, etc

--- a/staging_docs/dev/tutorials/getting-started.md
+++ b/staging_docs/dev/tutorials/getting-started.md
@@ -1,0 +1,27 @@
+# Getting Started
+
+## Install the package
+
+Install it as any python package using your preferred method.
+
+=== "pipx"
+
+    ```bash
+    pipx install git+https://github.com/pulp/pulp-docs --include-deps
+    ```
+
+=== "pip"
+
+    ```bash
+    pip --user install git+https://github.com/pulp/pulp-docs
+    ```
+
+## Start serving
+
+By default, `pulp-docs` will try to use repos in the parent dir that matches on of the supported plugins.
+
+Assure you are in a supported repo directory and run:
+
+```bash
+pulp-docs serve
+```

--- a/staging_docs/index.md
+++ b/staging_docs/index.md
@@ -38,7 +38,7 @@ hide:
 
     ---
 
-    Learn why important projects rely on Pulp to manage the lifecyle of huge *Software Content* collections.
+    Learn why important projects rely on Pulp to manage the lifecycle of huge *Software Content* collections.
 
     [:octicons-arrow-right-24: Features](site:help/more/why-pulp/)
 

--- a/staging_docs/sections/admin/index.md
+++ b/staging_docs/sections/admin/index.md
@@ -19,7 +19,7 @@ Common needs are to *configure, deploy and maintain Pulp instances*.
 
     ---
 
-    Start developing your service or application by levaraging our powerfull deployment setups.
+    Start developing your service or application by levaraging our powerful deployment setups.
     
 - **Engage**
 

--- a/staging_docs/sections/dev/index.md
+++ b/staging_docs/sections/dev/index.md
@@ -27,7 +27,7 @@ Common needs are to *improve docs, fix bugs and add features*.
     
     ---
 
-    Dive-in into Pulp code and architecture to help extend, improve and move the project foward.
+    Dive-in into Pulp code and architecture to help extend, improve and move the project forward.
 
     
 </div>

--- a/staging_docs/sections/help/index.md
+++ b/staging_docs/sections/help/index.md
@@ -7,7 +7,7 @@ Understaning the docs will help you find what you need more quickly.
 
 For some human help, you should visit the [Get Involved](site:pulp-docs/docs/sections/help/community/00_get-involved/) section.
 There you'll learn about how to can reach out to the Pulp Community.
-Don't hesistate to contact us!
+Don't hesitate to contact us!
 
 ---
 

--- a/staging_docs/sections/user/index.md
+++ b/staging_docs/sections/user/index.md
@@ -19,7 +19,7 @@ while **admin** needs are to *configure, deploy and maintain Pulp instances*.
 
     ---
     
-    Complete the starter tutorial to learn in pratice the basics of managing content in Pulp.
+    Complete the starter tutorial to learn in practice the basics of managing content in Pulp.
 
     
 -   **Understand the docs**


### PR DESCRIPTION
This adds a generated ToC on the main plugin namespace for both User and Developer Manuals.

Also, the documentation of pulp-docs itself was slightly improved to fit the idea of the overview pages.

Closes #49 

## Screenshots

![image](https://github.com/pulp/pulp-docs/assets/7907864/19955bd7-b8bd-4330-a2a3-9b2c21ceb14d)
