### PR TITLE
Add script for generating, commiting and pushing openapi json files

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -1,0 +1,36 @@
+name: "Update Data Branch"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 0,3"  # every sunday and wednesday at midnight
+
+jobs:
+  update-data:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v4"
+      - name: "Set up Python"
+        uses: "actions/setup-python@v5"
+        with:
+          python-version: "3.11"
+
+      - name: "List requirements"
+        run: |
+          cat requirements_system.txt
+          cat requirements_python.txt
+
+      - name: "Install System dependencies"
+        run: |
+          xargs sudo apt -y install < requirements_ubuntu.txt
+
+      - name: "Install Python dependencies"
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements_python.txt
+
+      - name: "Generate, commit and push updated openapi json files to 'docs-data' branch"
+        run: |
+          git config user.name github-actions
+          git config user.email github-action@github.com
+          ./update-data.sh

--- a/requirements_python.txt
+++ b/requirements_python.txt
@@ -1,0 +1,1 @@
+pulp-docs @ git+https://github.com/pulp/pulp-docs@main

--- a/requirements_ubuntu.txt
+++ b/requirements_ubuntu.txt
@@ -1,0 +1,8 @@
+libgirepository1.0-dev
+gcc
+libcairo2-dev
+pkg-config
+python3-dev
+gir1.2-gtk-4.0
+python3-gi
+gir1.2-ostree-1.0

--- a/update-data.sh
+++ b/update-data.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -eu -o pipefail
+
+# generate data
+python -m pulp_docs.openapi data/openapi_json
+
+# commit changes
+BRANCH=$(git branch --show-current)
+if ! [[ "${BRANCH}" = "docs-data" ]]
+then
+  echo ERROR: This is not a data-branch!
+  exit 1
+fi
+
+git add data/*
+git commit -m "Update data files: $(date --iso-8601=minutes)"
+git push origin docs-data


### PR DESCRIPTION
About this PR:

- Depends on: https://github.com/pulp/pulp-docs/pull/59
- This want to merge to the docs-data branch, which should only hold the openapi {plugin}-api.json files
- Adds a script that generates the json api files and commit/push them to docs-data branch.
- Add a CI workflow that uses this script and can be triggered manually or via cron