### PR TITLE
Fix blog doesn't showing up in docs (build)

### DIFF
--- a/src/pulp_docs/cli.py
+++ b/src/pulp_docs/cli.py
@@ -99,6 +99,7 @@ def build(ctx: PulpDocsContext):
     pulpdocs = ctx.pulp_docs
 
     config.verbose = True
+    config.disabled = ""
 
     dry_run = True if config.test_mode else False
     pulpdocs.build(config, dry_run=dry_run)

--- a/src/pulp_docs/data/mkdocs.yml
+++ b/src/pulp_docs/data/mkdocs.yml
@@ -42,7 +42,7 @@ plugins:
   - search
   - site-urls
   - blog:
-      blog_dir: pulp-docs/docs/sections/blog
+      blog_dir: blog
       blog_toc: false
   - macros:
       module_name: '../mkdocs_macros'

--- a/src/pulp_docs/repository.py
+++ b/src/pulp_docs/repository.py
@@ -125,11 +125,11 @@ class Repo:
         log.info(f"{log_header}: source={download_from}, copied_from={src_copy_path}")
 
         # ignore files lisetd in .gitignore and files that starts with "."
+        # shutil ignore limitation: https://github.com/Miserlou/Zappa/issues/692#issuecomment-283012663
         ignore_patterns = get_git_ignored_files(Path(src_copy_path)) + [".*"]
 
         # skip blog for faster reloads
         if self.name == "pulp-docs" and "blog" in disabled:
-            # limitation: https://github.com/Miserlou/Zappa/issues/692#issuecomment-283012663
             ignore_patterns.append("*posts")
 
         shutil.copytree(


### PR DESCRIPTION
The change in the sections url (https://github.com/pulp/pulp-docs/pull/56) broke the blog building.