### PR TITLE
Add proper version information in quick-links page

### DIFF
--- a/docs/sections/help/index.md
+++ b/docs/sections/help/index.md
@@ -11,7 +11,16 @@ Don't hesitate to contact us!
 
 ---
 
-## Quick Links (WIP)
+## Quick Links
+
+!!! note "About versions"
+
+    The `version` column is the latest on main and it's what we publish.
+
+    You might encounter some unreleased content live, but plugins usually release often.
+    Also, we try to include version information on the docs itself.
+
+### Content Plugins
 
 {% for repo_type in ("core", "content") %}
 Repo | Version | Links | &nbsp; | &nbsp;
@@ -20,6 +29,24 @@ Repo | Version | Links | &nbsp; | &nbsp;
 {{ repo.title }} | `{{ repo.version }}` | {{ repo.restapi_link }} | {{ repo.codebase_link }} | {{ repo.changes_link }}
 {% endfor %}
 {% endfor %}
+
+### Deployment
+
+Repo | Version | Links | &nbsp;
+--- | --- | --- | ---
+{% for repo in get_repos("deployment") -%}
+{{ repo.title }} | `{{ repo.version }}` | {{ repo.codebase_link }} | {{ repo.changes_link }}
+{% endfor %}
+
+### Interaction
+
+Repo | Version | Links | &nbsp;
+--- | --- | --- | ---
+{% for repo in get_repos("interaction") -%}
+{{ repo.title }} | `{{ repo.version }}` | {{ repo.codebase_link }} | {{ repo.changes_link }}
+{% endfor %}
+
+### Others
 
 Repo | Version | Links | &nbsp;
 --- | --- | --- | ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pulp-docs"
 version = "0.0.1"
+requires-python = ">= 3.11"
 dependencies = [
     "mkdocs-material",
     "mkdocstrings",
@@ -13,10 +14,8 @@ dependencies = [
     "mkdocs-site-urls",
     "mkdocs-literate-nav",
     "bs4",
-    "importlib_resources",
     "httpx",
     "rich",
-    "tomli",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "importlib_resources",
     "httpx",
     "rich",
+    "tomli",
 ]
 
 [project.scripts]

--- a/src/pulp_docs/main.py
+++ b/src/pulp_docs/main.py
@@ -4,7 +4,7 @@ import sys
 import typing as t
 from pathlib import Path
 
-from importlib_resources import files
+from importlib.resources import files
 
 TMP_DIR = Path("tmp")
 WORKDIR = Path.home() / "workspace" / "multirepo-prototype"
@@ -36,8 +36,8 @@ class Config:
         if from_environ is False:
             self.verbose = False
             self.workdir = Path().absolute()
-            self.mkdocs_file = files("pulp_docs").joinpath("data/mkdocs.yml").absolute()
-            self.repolist = files("pulp_docs").joinpath("data/repolist.yml").absolute()
+            self.mkdocs_file = files("pulp_docs").joinpath("data/mkdocs.yml")
+            self.repolist = files("pulp_docs").joinpath("data/repolist.yml")
             self.clear_cache = False
 
             if env_mkdocs := os.environ.get("PULPDOCS_MKDOCS_FILE"):

--- a/src/pulp_docs/mkdocs_macros.py
+++ b/src/pulp_docs/mkdocs_macros.py
@@ -118,6 +118,7 @@ def prepare_repositories(TMPDIR: Path, repos: Repos, config: Config):
             )
         else:
             this_src_dir = repo_sources / repo_or_pkg.subpackage_of / repo_or_pkg.name
+            repo_or_pkg.version = f"same as {repo_or_pkg.subpackage_of}"
 
         # restapi
         if has_restapi(repo_or_pkg):
@@ -432,8 +433,10 @@ def define_env(env):
         )
         repos_data = [
             {
-                "title": repo.title,
-                "version": "3.12.1",
+                "title": "[{title}](site:{name}/)".format(
+                    title=repo.title, name=repo.name
+                ),
+                "version": repo.version or "unknonwn",
                 "restapi_link": MD_LINK.format(
                     title="REST API", path=f"{repo.name}/restapi/"
                 ),
@@ -441,7 +444,9 @@ def define_env(env):
                     title="Changelog", path=f"{repo.name}/changes/"
                 ),
                 "codebase_link": GITHUB_LINK.format(
-                    title="Codebase", owner=repo.owner, name=repo.name
+                    title="Repository",
+                    owner=repo.owner or "pulp",
+                    name=getattr(repo, "subpackage_of", repo.name),
                 ),
             }
             for repo in repos_list

--- a/src/pulp_docs/openapi.py
+++ b/src/pulp_docs/openapi.py
@@ -10,7 +10,7 @@ import tempfile
 from pathlib import Path
 from typing import NamedTuple, Optional
 
-from importlib_resources import files
+from importlib.resources import files
 
 from pulp_docs.constants import BASE_TMPDIR_NAME
 from pulp_docs.repository import Repos
@@ -20,7 +20,7 @@ def main(
     output_dir: Path, plugins_filter: Optional[list[str]] = None, dry_run: bool = False
 ):
     """Creates openapi json files for all or selected plugins in output dir."""
-    repolist = files("pulp_docs").joinpath("data/repolist.yml").absolute()
+    repolist = str(files("pulp_docs").joinpath("data/repolist.yml"))
     repos = Repos.from_yaml(repolist).get_repos(["content"])
     if plugins_filter:
         repos = [p for p in repos if p.name in plugins_filter]

--- a/src/pulp_docs/repository.py
+++ b/src/pulp_docs/repository.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 import httpx
 import configparser
-import tomli
+import tomllib
 import yaml
 
 from pulp_docs.utils.general import get_git_ignored_files
@@ -151,7 +151,7 @@ class Repo:
         else:
             version_file = src_copy_path / "pyproject.toml"
             if version_file.exists():
-                content = tomli.loads(version_file.read_text())
+                content = tomllib.loads(version_file.read_text())
                 self.version = (
                     content.get("tool", {})
                     .get("bumpversion", {})

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 requires =
     tox>=4
-env_list = py{38,39,310,311,312}
+env_list = py{311,312}
 
 [testenv]
 description = run tests


### PR DESCRIPTION
This does:
- Uses repository files (bumpversion and pyproject) to determine the version being published (usually a development version).
- Add missing repositories to the quick links table
- Add links to the index pages

## Screenshots

![image](https://github.com/user-attachments/assets/41a9ae93-a7c2-46e6-b061-79c880a780a8)
