### PR TITLE
Disable mkdocs-macro global jinja usage

### DIFF
--- a/docs/sections/help/index.md
+++ b/docs/sections/help/index.md
@@ -1,3 +1,7 @@
+---
+render_macros: true
+---
+
 # Overview
 
 :wave: Welcome to the help section!

--- a/src/pulp_docs/data/mkdocs.yml
+++ b/src/pulp_docs/data/mkdocs.yml
@@ -46,6 +46,7 @@ plugins:
       blog_toc: false
   - macros:
       module_name: '../mkdocs_macros'
+      render_by_default: false
   - tags:
       tags_file: pulp-docs/docs/tags.md
   - literate-nav:


### PR DESCRIPTION
There is no need to enable jinja for all doc pages, as mkdocs-macro does by default.
Closes https://github.com/pulp/pulp-operator/issues/1309

## Reference

https://mkdocs-macros-plugin.readthedocs.io/en/latest/rendering/#solution-2-opt-in-specify-which-pages-must-be-rendered
