### PR TITLE
Fix rest_api spec being fetched from outdated link

### DIFF
--- a/src/pulp_docs/mkdocs_macros.py
+++ b/src/pulp_docs/mkdocs_macros.py
@@ -31,7 +31,6 @@ from pulp_docs.cli import Config
 from pulp_docs.constants import SECTION_REPO
 from pulp_docs.navigation import get_navigation
 from pulp_docs.repository import Repo, Repos, SubPackage
-from pulp_docs.utils.general import get_label
 
 # the name of the docs in the source repositories
 SRC_DOCS_DIRNAME = "staging_docs"
@@ -122,7 +121,7 @@ def prepare_repositories(TMPDIR: Path, repos: Repos, config: Config):
 
         # restapi
         if has_restapi(repo_or_pkg):
-            _download_api_json(api_src_dir, repo_or_pkg.name)
+            _download_api_json(api_src_dir, repo_or_pkg.name, repo_or_pkg.app_label)
             _generate_rest_api_page(this_src_dir, repo_or_pkg.name, repo_or_pkg.title)
 
         # install and post-process
@@ -145,14 +144,13 @@ def prepare_repositories(TMPDIR: Path, repos: Repos, config: Config):
     return (repo_docs, repo_sources)
 
 
-def _download_api_json(api_dir: Path, repo_name: str):
+def _download_api_json(api_dir: Path, repo_name: str, app_label: str):
     api_json_path = api_dir / f"{repo_name}/api.json"
     if api_json_path.exists():
         log.info(f"{repo_name} api.json already downloaded.")
         return
 
     log.info(f"Downloading api.json for {repo_name}")
-    app_label = get_label(repo_name)
     api_url = f"https://raw.githubusercontent.com/pulp/pulp-docs/docs-data/data/openapi_json/{app_label}-api.json"
     response = httpx.get(api_url)
     if response.is_error:

--- a/src/pulp_docs/mkdocs_macros.py
+++ b/src/pulp_docs/mkdocs_macros.py
@@ -31,7 +31,7 @@ from pulp_docs.cli import Config
 from pulp_docs.constants import SECTION_REPO
 from pulp_docs.navigation import get_navigation
 from pulp_docs.repository import Repo, Repos, SubPackage
-from pulp_docs.utils.general import get_git_ignored_files
+from pulp_docs.utils.general import get_label
 
 # the name of the docs in the source repositories
 SRC_DOCS_DIRNAME = "staging_docs"
@@ -152,13 +152,11 @@ def _download_api_json(api_dir: Path, repo_name: str):
         return
 
     log.info(f"Downloading api.json for {repo_name}")
-    api_url_1 = "https://pulpproject.org/{repo_name}/api.json"
-    api_url_2 = "https://pulpproject.org/{repo_name}/_static/api.json"
-    response = httpx.get(api_url_1.format(repo_name=repo_name))
+    app_label = get_label(repo_name)
+    api_url = f"https://raw.githubusercontent.com/pulp/pulp-docs/docs-data/data/openapi_json/{app_label}-api.json"
+    response = httpx.get(api_url)
     if response.is_error:
-        response = httpx.get(api_url_2.format(repo_name=repo_name))
-    if response.is_error:
-        raise Exception("Couldnt get rest api page")
+        raise Exception("Couldnt get rest api schema for {app_label}")
 
     # Schema overrides for better display
     json_file_content = response.json()

--- a/src/pulp_docs/utils/general.py
+++ b/src/pulp_docs/utils/general.py
@@ -2,6 +2,17 @@ import typing as t
 from pathlib import Path
 
 
+def get_label(repo_name: str):
+    """Get app_label from repo_name.
+
+    E.g: 'pulp_ostree' -> 'ostree'.
+    """
+    if repo_name == "pulpcore":
+        return "core"
+    # E.g: "pulp-ostree" -> "pulp_ostree" -> ("", "pulp_", "ostree")
+    return repo_name.replace("-", "_").rpartition("pulp_")[2]
+
+
 def get_git_ignored_files(repo_path: Path) -> t.List[str]:
     """Get list of ignored files as defined in the repo .gitignore"""
     repo_gitignore = Path(repo_path / ".gitignore")

--- a/src/pulp_docs/utils/general.py
+++ b/src/pulp_docs/utils/general.py
@@ -2,17 +2,6 @@ import typing as t
 from pathlib import Path
 
 
-def get_label(repo_name: str):
-    """Get app_label from repo_name.
-
-    E.g: 'pulp_ostree' -> 'ostree'.
-    """
-    if repo_name == "pulpcore":
-        return "core"
-    # E.g: "pulp-ostree" -> "pulp_ostree" -> ("", "pulp_", "ostree")
-    return repo_name.replace("-", "_").rpartition("pulp_")[2]
-
-
 def get_git_ignored_files(repo_path: Path) -> t.List[str]:
     """Get list of ignored files as defined in the repo .gitignore"""
     repo_gitignore = Path(repo_path / ".gitignore")


### PR DESCRIPTION
On the time of the docs transitioning pulp-docs was using the legacy server as a source of the api.json, which were doomed to become outdated. This was mostly to keep CI working while the solution was being implemented.

Now that the api schemas for docs are being generated in pulp-docs repo, we can use that as the up-to-date source.

Closes: #84