### PR TITLE
Ignore conventional private files starting with _  (mkdocstrings)

### DIFF
--- a/src/pulp_docs/data/mkdocs.yml
+++ b/src/pulp_docs/data/mkdocs.yml
@@ -58,8 +58,9 @@ plugins:
             show_source: false
             show_symbol_type_heading: true
             show_symbol_type_toc: true
-            docstring_section_style: table # table, list, spacy
-            # heading_level: 2
+            docstring_section_style: list # table, list, spacy
+            filters: ["!^_"]
+            heading_level: 2
             show_root_heading: true
             show_root_toc_entry: true
             show_if_no_docstring: false

--- a/src/pulp_docs/data/repolist.yml
+++ b/src/pulp_docs/data/repolist.yml
@@ -26,6 +26,10 @@ repos:
       owner: pulp
       title: Pulp CLI
       branch: main
+    - name: pulp-ui
+      owner: pulp
+      title: Pulp UI
+      branch: main
   content:
     - name: pulp_maven
       owner: pulp


### PR DESCRIPTION
Ignores conventional private methods and attrs starting with "_".
https://mkdocstrings.github.io/python/usage/configuration/members/#filters
