### PR TITLE
Add rss-listing and link in help page

### DIFF
--- a/docs/sections/help/index.md
+++ b/docs/sections/help/index.md
@@ -11,6 +11,7 @@ Understaning the docs will help you find what you need more quickly.
 
 For some human help, you should visit the [Get Involved](site:help/community/get-involved/) section.
 There you'll learn about how to can reach out to the Pulp Community.
+
 Don't hesitate to contact us!
 
 ---
@@ -56,4 +57,12 @@ Repo | Version | Links | &nbsp;
 --- | --- | --- | ---
 {% for repo in get_repos("other") -%}
 {{ repo.title }} | `{{ repo.version }}` | {{ repo.codebase_link }} | {{ repo.changes_link }}
+{% endfor %}
+
+## Changes RSS Feed
+
+Check our recent releases with this [RSS changelog feed](https://himdel.eu/feed/pulp-changes.json).
+
+{% for item in rss_items() %}
+- [{{ item.title }}]({{ item.url }})
 {% endfor %}

--- a/src/pulp_docs/mkdocs_macros.py
+++ b/src/pulp_docs/mkdocs_macros.py
@@ -449,6 +449,23 @@ def define_env(env):
         ]
         return repos_data
 
+    @env.macro
+    def rss_items():
+        # that's Himdel's rss feed: https://github.com/himdel
+        response = httpx.get("https://himdel.eu/feed/pulp-changes.json")
+        if response.is_error:
+            return {
+                "items": [
+                    {
+                        "url": "#",
+                        "title": "Couldnt fetch the feed. Please, open an issue in https://github.com/pulp/pulp-docs/.",
+                    }
+                ]
+            }
+
+        rss_feed = json.loads(response.content)
+        return rss_feed["items"][:20]
+
 
 def on_pre_page_macros(env):
     """The mkdocs-macros hook just before an inidvidual page render."""


### PR DESCRIPTION
This adds @himdel [rss feed link](https://himdel.eu/feed/pulp-changes.json) into pulp website and a simple listing of it's content.

Its added to the end of the help page (after quicklinks).

![image](https://github.com/user-attachments/assets/35f2082a-b8c1-4df3-a4de-0001c79e846a)
