### PR TITLE
User and Dev Manual Header pages: add links to other sections

### DIFF
--- a/docs/sections/dev/index.md
+++ b/docs/sections/dev/index.md
@@ -20,7 +20,11 @@ Common needs are to *improve docs, fix bugs and add features*.
 
     ---
     
-    Learn the basic for contributing to Pulp: opening PRs, code style, releases cycles and versioning.
+    Learn the basics for contributing to Pulp: opening PRs, code style, releases cycles and versioning.
+
+    [Contributing Code](site:pulpcore/docs/dev/tutorials/quickstart/)
+
+    [Contributing Documentation](site:pulpcore/docs/dev/tutorials/quickstart-docs)
 
     
 -   **Deep Dive**
@@ -28,6 +32,8 @@ Common needs are to *improve docs, fix bugs and add features*.
     ---
 
     Dive-in into Pulp code and architecture to help extend, improve and move the project forward.
+ 
+    [Architecture](site:pulpcore/docs/admin/learn/architecture/)
 
     
 </div>

--- a/docs/sections/help/more/docs-usage.md
+++ b/docs/sections/help/more/docs-usage.md
@@ -1,3 +1,10 @@
 # Documentation Usage
 
-EDITME
+The Pulp Documentation provides comprehensive information on managing, distributing, and maintaining repositories of software packages. 
+This guide will help you navigate and make the most of Pulp's documentation.
+
+---
+
+## Table of Contents
+- [Start Here](site:pulpcore/docs/user/tutorials/)
+

--- a/docs/sections/user/index.md
+++ b/docs/sections/user/index.md
@@ -19,15 +19,14 @@ while **admin** needs are to *configure, deploy and maintain Pulp instances*.
 
     ---
     
-    Complete the starter tutorial to learn in practice the basics of managing content in Pulp.
-
+    Complete the [start tutorial](site:pulpcore/docs/user/tutorials/) to learn in practice the basics of managing content in Pulp.
     
 -   **Understand the docs**
     
     ---
 
     Pulp has a rich ecosystem of plugins.
-    Understanding the docs can help you find information more efficiently.
+    [Understanding the docs](site:help/more/docs-usage) can help you find information more efficiently.
 
 </div>
 </div>


### PR DESCRIPTION
* Felt weird reading these high traffic pages with references to other pages and guide but no link to click
* Attempt to improve that by adding in these links