### PR TITLE
Enable rendering template: pulp-docs/docs/rest_api

### DIFF
--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -1,3 +1,7 @@
+---
+render_macros: true
+---
+
 # Rest API
 
 The REST API reference for Pulp Plugins is generated using [ReDoc](https://redocly.com/redoc/) and are published in standalone pages:


### PR DESCRIPTION
Commit `b7e3d41` disabled global rendering of templates. This broke `rest_api.md` rendering as it did not have the render template header set.

Closes #100 