### PR TITLE
Add word 'organize' to the home page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ hide:
 
 ![Pulp Logo](site:pulpcore/docs/assets/pulp_logo_big.png)
 
-## Pulp is an open source project that makes it easy for developers to fetch, upload, and distribute *Software Packages* on-prem or in the cloud. {: #pulp-project}
+## Pulp is an open source project that makes it easy for developers to **fetch**, **upload**, **organize** and **distribute** *Software Packages* on-prem or in the cloud. {: #pulp-project}
 
 </div>
 


### PR DESCRIPTION
The word "organize" was left out of the headline on the docs transitioning.