### PR TITLE
Fix build error caused by blog tags not being a list

### DIFF
--- a/docs/sections/blog/posts/2021/2021-06-28-tasking-event-blog.md
+++ b/docs/sections/blog/posts/2021/2021-06-28-tasking-event-blog.md
@@ -2,7 +2,7 @@
 date: 2021-06-28T20:55:50+00:00
 title: New Tasking System Event
 author: Melanie Corr
-tags: event
+tags: [event]
 ---
 <!-- more -->
 ## Pulp Community YouTube Live Event

--- a/docs/sections/blog/posts/2022/2022-09-19-pulp-2-eol.md
+++ b/docs/sections/blog/posts/2022/2022-09-19-pulp-2-eol.md
@@ -3,7 +3,7 @@ date: 2022-09-19T20:55:50+00:00
 title: Pulp 2 End of Life Announcement
 author: Ina Panova
 tags:
-    - pulp2, eol
+  - pulp2, eol
 ---
 <!-- more -->
 ## Pulp 2 End of Life Announcement

--- a/docs/sections/blog/posts/2022/2022-11-01-pulpcon-2022-schedule.md
+++ b/docs/sections/blog/posts/2022/2022-11-01-pulpcon-2022-schedule.md
@@ -3,7 +3,7 @@ date: 2022-11-01T20:55:50+00:00
 title: Pulpcon 2022 Schedule
 author: Dennis Kliban
 tags:
-    - pulpcon, community
+  - pulpcon, community
 ---
 <!-- more -->
 ## Virtual Pulpcon - November 7-11, 2022 Schedule

--- a/docs/sections/blog/posts/2023/2023-02-14-rpm-redirect-serving-perf-scale-testing.md
+++ b/docs/sections/blog/posts/2023/2023-02-14-rpm-redirect-serving-perf-scale-testing.md
@@ -3,7 +3,7 @@ date: 2023-02-14T20:55:50+00:00
 title: RPM Content Service Performance and Scale Testing
 author: Brian Bouterse
 tags:
-    - pulp_rpm, performance
+  - pulp_rpm, performance
 ---
 <!-- more -->
 ## Goals

--- a/docs/sections/blog/posts/2024/2024-11-06-pulp-ui-beta.md
+++ b/docs/sections/blog/posts/2024/2024-11-06-pulp-ui-beta.md
@@ -3,7 +3,7 @@ date: 2024-11-11T08:55:50+00:00
 title: Pulp UI Beta out now in Pulp images
 author: Gerrod Ubben
 tags:
-    - announcement  
+  - announcement
 ---
 
 Pulp-UI (beta) is now available in the latest `pulp/pulp` image. This was a huge effort over the 

--- a/docs/sections/blog/posts/pulp2/2016-05-17-pulp-2-8-3-released-security-bug-fixes.md
+++ b/docs/sections/blog/posts/pulp2/2016-05-17-pulp-2-8-3-released-security-bug-fixes.md
@@ -7,7 +7,7 @@ author: Sean Myers
 layout: post
 guid: http://www.pulpproject.org/?p=1273
 permalink: /2016/05/17/pulp-2-8-3-released-security-bug-fixes/
-tags: release
+tags: [release]
 categories:
   - Uncategorized
 ---

--- a/docs/sections/blog/posts/pulp2/2017-08-02-2.14-Test-Day.md
+++ b/docs/sections/blog/posts/pulp2/2017-08-02-2.14-Test-Day.md
@@ -3,7 +3,7 @@ date: 2017-08-02T20:55:50+00:00
 title: Test Day for 2.14 Beta
 author: Elijah DeLee
 tags:
-    -pulpqe
+  - pulpqe
 ---
 <!-- more -->
 Test Day on August 8th, 2017


### PR DESCRIPTION
This is hitting the CI if the frontmatter (yaml) doesnt contain a list in the 'tags` field.

```
ERROR   -  Error reading page 'blog/posts/2021/2021-06-28-tasking-event-blog.md':
ERROR   -  Error reading tags of page 'blog/posts/2021/2021-06-28-tasking-event-blog.md' in '../../../../../../tmp/pulp-docs-tmp/repo_docs':
Expected iterable tags, but received: event

Aborted with a BuildError!
```

Couldnt reproduce locally.
Maybe some dependency changed how it handles this.