### PR TITLE
Bump mkdocstrings-python lowerbound and add upperboud

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">= 3.11"
 dependencies = [
     "mkdocs-material",
     "mkdocstrings",
-    "mkdocstrings-python>=1.9.1",
+    "mkdocstrings-python>=1.14.1,<1.15",
     "mkdocs-macros-plugin",
     "mkdocs-site-urls",
     "mkdocs-literate-nav",


### PR DESCRIPTION
I though I would have to pin mkdocstrings-python back, but bumping to >=1.14.1 works.
Probably [this bugfix](https://mkdocstrings.github.io/python/changelog/#bug-fixes).

Fixes #107 