### PR TITLE
Add proper preview bounds to checkpoint blog post

### DIFF
--- a/docs/sections/blog/posts/2023/2023-02-14-rpm-redirect-serving-perf-scale-testing.md
+++ b/docs/sections/blog/posts/2023/2023-02-14-rpm-redirect-serving-perf-scale-testing.md
@@ -5,7 +5,7 @@ author: Brian Bouterse
 tags:
   - pulp_rpm, performance
 ---
-<!-- more -->
+
 ## Goals
 
 1. Help pulp_rpm users plan the number of pulp-content apps to serve a given traffic rate for their 
@@ -20,6 +20,7 @@ To achieve these goals in this blog post, I'll be doing two things:
 
 * Identify rate limiting components in various test scenarios.
 
+<!-- more -->
 
 ## Conclusions
 

--- a/docs/sections/blog/posts/2025/checkpoint.md
+++ b/docs/sections/blog/posts/2025/checkpoint.md
@@ -16,6 +16,8 @@ Inspired by the success stories of [Ubuntu Snapshots on Azure](https://ubuntu.co
 [increased security and resiliency of Canonical workloads on Azure](https://techcommunity.microsoft.com/blog/linuxandopensourceblog/increased-security-and-resiliency-of-canonical-workloads-on-azure---now-in-previ/3970623), we
 embarked on a journey to develop a feature that could address these challenges.
 
+<!-- more -->
+
 ## The Problem
 
 Imagine working on a project where you need to ensure that your deployment environment is consistent


### PR DESCRIPTION
Without that, the blog page with the posts listing displays all the content of the post.
The `<!-- more -->` tag separates what should be handled as the listing preview.

Also added a preview to the performance post, which had none.