### PR TITLE
Fix redocly menu render and missing logo

### DIFF
--- a/custom/rest_api.html
+++ b/custom/rest_api.html
@@ -4,18 +4,34 @@
 {{ super() }}
 <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
 <style>
+  /* Fit and expand redoc block below mkdocs menu */
   article.md-content__inner {margin: 0; padding: 0;}
   article.md-content__inner::before {height: 0;}
   div.md-main__inner {margin: 0;}
-  div.md-grid {max-width: none;}
+  div.md-main__inner {max-width: none;}
+  /* Add some padding to the logo div and reduce it's size */
+  .menu-content > div:first-child {padding: 1rem;}
+  .menu-content > div:first-child img {width: 80%; height: auto;}
 </style>
 {% endblock %}
 
 {% block site_nav %}
 {% endblock %}
 
-{% block content %}
-<redoc spec-url="../api.json"></redoc>
+<!-- Container Snippet taken from: -->
+<!-- https://github.com/squidfunk/mkdocs-material/blob/master/material/templates/base.html -->
+{% block container %}
+  <div class="md-content" data-md-component="content">
+    <article class="md-content__inner md-typeset">
+      {% block content %}
+        {% include "partials/content.html" %}
+      {% endblock %}
+    </article>
+    <!-- Redoc must be out of <article> or it'll break the page -->
+    <div class="pulp-redoc">
+      <redoc spec-url="../api.json"></redoc>
+    </div>
+  </div>
 {% endblock %}
 
 {% block scripts %}

--- a/src/pulp_docs/plugin.py
+++ b/src/pulp_docs/plugin.py
@@ -24,6 +24,8 @@ REST_API_MD = """\
 ---
 template: "rest_api.html"
 ---
+
+# Rest API - {component} {{.hide-h1}}
 """
 
 
@@ -369,7 +371,7 @@ class PulpDocsPlugin(BasePlugin[PulpDocsPluginConfig]):
                     File.generated(
                         config,
                         src_uri,
-                        content=REST_API_MD,
+                        content=REST_API_MD.format(component=component.title),
                     )
                 )
                 component_nav.add(src_uri)
@@ -383,6 +385,10 @@ class PulpDocsPlugin(BasePlugin[PulpDocsPluginConfig]):
                     api_json = pulp_docs_git.git.show(
                         f"{remote}/docs-data:data/openapi_json/{component.rest_api}-api.json"
                     )
+                # fix the logo url for restapi page, which is defined in the openapi spec file
+                api_json = api_json.replace(
+                    "/pulp-docs/docs/assets/pulp_logo_icon.svg", "/assets/pulp_logo_icon.svg"
+                )
                 src_uri = (component_dir / "api.json").relative_to(component_parent_dir)
                 files.append(File.generated(config, src_uri, content=api_json))
 


### PR DESCRIPTION
The last rewrite changed the position of the <redoc> element, breaking it's menu expand behavior.

Also, the assets dir changed, which caused pulp logo on that page to not be found. It's url is hardcoded in the openapi json schema.

closes: #138