### PR TITLE
Add banner to market PulpCon 2025

### DIFF
--- a/custom/main.html
+++ b/custom/main.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{# https://squidfunk.github.io/mkdocs-material/setup/setting-up-the-header/#announcement-bar #}
+{% block announce %}
+  🍊 <b>Virtual PulpCon 2025 is coming!</b>
+  Learn more and/or submit a talk
+  <a href="https://discourse.pulpproject.org/t/virtual-pulpcon-2025/2119" target="_blank" rel="noopener noreferrer">
+    here
+  </a>!
+  🍊
+{% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ theme:
     - content.code.annotation
     - content.code.copy
     - content.action.edit
+    - announce.dismiss  # enable users dismissing the announce banner
   language: en
   palette:
     - media: "(prefers-color-scheme: light)"


### PR DESCRIPTION
Just advertising PulpCon 2025!

## Screenshots

<img width="1303" height="183" alt="image" src="https://github.com/user-attachments/assets/b01b8716-5f9b-4b71-8634-eff0044f6606" />

<img width="1303" height="183" alt="image" src="https://github.com/user-attachments/assets/9149823e-b06f-47e8-af19-d081f5b1b078" />
