### PR TITLE
Fix mkdocstrings not founding component src code

### DIFF
--- a/src/pulp_docs/plugin.py
+++ b/src/pulp_docs/plugin.py
@@ -330,7 +330,8 @@ class PulpDocsPlugin(BasePlugin[PulpDocsPluginConfig]):
         for component in self.config.components:
             components_var.append(get_component_data(component))
             config.watch.append(str(component.component_dir / "docs"))
-            mkdocstrings_config.handlers["python"]["paths"].append(str(component.component_dir))
+            component_dir = str(component.component_dir.resolve())
+            mkdocstrings_config.handlers["python"]["paths"].append(component_dir)
 
         macros_plugin = config.plugins["macros"]
         macros_plugin.register_macros({"rss_items": rss_items})


### PR DESCRIPTION
We were passing a relative path to the components, which makes it not be able to find the repository for  certain configurations of repository locations. Making the path aboslute/resolved should work in more general situations.