### PR TITLE
Fix build script for docs publishing

### DIFF
--- a/.github/workflows/scripts/build_all_docs.sh
+++ b/.github/workflows/scripts/build_all_docs.sh
@@ -7,5 +7,5 @@ set -euv
 FETCHDIR="/tmp/fetchdir"
 pip install .
 pulp-docs fetch --dest "$FETCHDIR"
-pulp-docs build --path "$FETCHDIR"
+pulp-docs build --path "pulp-docs@..:$FETCHDIR"
 tar cvf pulpproject.org.tar site


### PR DESCRIPTION
It should use the CI checkout, otherwise it won't find the docs assets at the `docs-data` branch.

The publish error:
https://github.com/pulp/pulp-docs/actions/runs/18269049416/job/52008314377

```python
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.13.7/x64/bin/pulp-docs", line 7, in <module>
    sys.exit(main())
             ~~~~^^
  File "/opt/hostedtoolcache/Python/3.13.7/x64/lib/python3.13/site-packages/click/core.py", line 1462, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.13.7/x64/lib/python3.13/site-packages/click/core.py", line 1383, in main
    rv = self.invoke(ctx)
  File "/opt/hostedtoolcache/Python/3.13.7/x64/lib/python3.13/site-packages/click/core.py", line 1850, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.13.7/x64/lib/python3.13/site-packages/click/core.py", line 1246, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.13.7/x64/lib/python3.13/site-packages/click/core.py", line 814, in invoke
    return callback(*args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.13.7/x64/lib/python3.13/site-packages/mkdocs/__main__.py", line 288, in build_command
    build.build(cfg, dirty=not clean)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.13.7/x64/lib/python3.13/site-packages/mkdocs/commands/build.py", line 292, in build
    files = config.plugins.on_files(files, config=config)
  File "/opt/hostedtoolcache/Python/3.13.7/x64/lib/python3.13/site-packages/mkdocs/plugins.py", line 593, in on_files
    return self.run_event('files', files, config=config)
           ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.13.7/x64/lib/python3.13/site-packages/mkdocs/plugins.py", line 566, in run_event
    result = method(item, **kwargs)
  File "/opt/hostedtoolcache/Python/3.13.7/x64/lib/python3.13/site-packages/pulp_docs/plugin.py", line 425, in on_files
    api_json_content = self.get_openapi_spec(component, pulp_docs_git)
  File "/opt/hostedtoolcache/Python/3.13.7/x64/lib/python3.13/site-packages/pulp_docs/plugin.py", line 497, in get_openapi_spec
    api_json = pulp_docs_git.git.show(
        f"{remote}/docs-data:data/openapi_json/{component.rest_api}-api.json"
    )
  File "/opt/hostedtoolcache/Python/3.13.7/x64/lib/python3.13/site-packages/git/cmd.py", line 1003, in <lambda>
    return lambda *args, **kwargs: self._call_process(name, *args, **kwargs)
                                   ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.13.7/x64/lib/python3.13/site-packages/git/cmd.py", line 1616, in _call_process
    return self.execute(call, **exec_kwargs)
           ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.13.7/x64/lib/python3.13/site-packages/git/cmd.py", line 1406, in execute
    raise GitCommandError(redacted_command, status, stderr_value, stdout_value)
git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)
  cmdline: git show origin/docs-data:data/openapi_json/core-api.json
  stderr: 'fatal: invalid object name 'origin/docs-data'.'
Error: Process completed with exit code 1.
```