### PR TITLE
Update redoc bundle link to point to the latests

### DIFF
--- a/custom/rest_api.html
+++ b/custom/rest_api.html
@@ -56,7 +56,7 @@
     </article>
 
     <div id="redoc-container"></div>
-    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@latest/bundles/redoc.standalone.js"></script>
     <script>
     const SPEC_URL = "../api.json";
     const REDOC_CONTAINER = document.getElementById('redoc-container');


### PR DESCRIPTION
`@next` points to an unreleased version which has changed `bundles` to `bundle` and break the link.