### PR TITLE
Update pulpcon last editions links and stats

### DIFF
--- a/pulpproject.org/help/community/pulpcon.md
+++ b/pulpproject.org/help/community/pulpcon.md
@@ -13,11 +13,14 @@ Stay tuned for our next editions in our [discourse] and [matrix] channels!
 
 Check out the material from previous editions:
 
-| Year | Date | #Talks | Schedule | Playlist |
-|------|------|--------|----------|----------|
-| 2025 | 01/12 - 3/12 | 15 | [View Schedule](https://hackmd.io/@pulp/pulpcon_2025_schedule) | [Watch Playlist](#) (TODO) |
+| Year | Date | PulpcoreAt |#Talks | Schedule | Playlist |
+|------|------|-----|----|----------|----------|
+| 2025 | Dec 01-03 | `3.94` | 15 | [View Schedule](https://hackmd.io/@pulp/pulpcon_2025_schedule) | Watch Playlist*
+| 2024 | Nov 04-06 | `3.67` | 9 | [View Schedule](https://hackmd.io/@pulp/pulpcon_2024_schedule) | [Watch Playlist](https://www.youtube.com/playlist?list=PLwm8_O6oKSS3UCjh9mIwqj3xocWxR5uVL) |
+| 2023 | Nov 06-10 | `3.40` | 20 | [View Schedule](https://hackmd.io/@pulp/pulpcon_2023) | [Watch Playlist](https://www.youtube.com/playlist?list=PLwm8_O6oKSS3ePzHYNH1pDjpZaJtHVT1q) |
+| 2022 | Nov 07-11 | `3.21` | 20 | [View Schedule](https://hackmd.io/@pulp/pulpcon2022_schedule) | [Watch Playlist](https://www.youtube.com/playlist?list=PLwm8_O6oKSS1twE1f6Z4W6UDJ-3IoDQ-8) |
+| 2021 | Nov 08-12 | `3.16` | 23 | [View Schedule](https://hackmd.io/@pulp/rysz3dEHF) | [Watch Playlist](https://www.youtube.com/playlist?list=PLwm8_O6oKSS29CRGD5URZiqdYEF2WHU1Q) |
 <!-- | 2024 | dd/mm - dd/mm | N | [View Schedule](#) | [Watch Playlist](#) | -->
-
 
 [at least since 2016]: site:blog/2017/04/19/maintaining-community-with-clear-goals/?h=PulpCon-2016
 [discourse]: https://discourse.pulpproject.org/


### PR DESCRIPTION
This PR does:
* Updates the info about last editions of PulpCon with proper links, dates and stats.
* Change date format (the world doesnt have a consensus if it should be mm/dd or dd/mm)

<img width="836" height="479" alt="image" src="https://github.com/user-attachments/assets/22202576-b803-491f-a179-e1cf470e6261" />

Got the pulpcore dates with:

```bash
git tag -l "3.*.0" | sort -V | while read tag; do
    if [ -n "$tag" ]; then
        # Get short SHA and commit date for the tag
        short_sha=$(git rev-parse --short "$tag")
        commit_date=$(git log -1 --format="%cd" --date=short "$tag")

        printf "%-12s %s %s\n" "$tag" "$short_sha" "$commit_date"
    fi
done
```