### PR TITLE
Add linkchecker cli tool

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: "https://github.com/pre-commit/pre-commit-hooks"
-    rev: "v5.0.0"
+    rev: "v6.0.0"
     hooks:
       - id: "trailing-whitespace"
         exclude: "^pulpproject.org"

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
 .PHONY: help
 help:
 	@echo "COMMANDS:"
-	@echo "    dist-build   Build the distribution package"
-	@echo "    dist-test    Test the built distribution package"
-	@echo "    docs-ci      Build docs for COMPONENT's CI"
-	@echo "    lint         Run pre-commit hooks on all files"
-	@echo "    clean        Remove build artifacts and temporary files"
-	@echo "    help         Show this help message"
+	@echo "    dist-build      Build the distribution package"
+	@echo "    dist-test       Test the built distribution package"
+	@echo "    docs-ci         Build docs for COMPONENT's CI"
+	@echo "    docs-linkcheck: Check for broken documentation links"
+	@echo "    test            Run the test suite"
+	@echo "    lint            Run pre-commit hooks on all files"
+	@echo "    clean           Remove build artifacts and temporary files"
+	@echo "    help            Show this help message"
 
 .PHONY: dist-build
 dist-build:
@@ -22,9 +24,19 @@ dist-test:
 	venv-dist/bin/twine check --strict dist/pulp_docs-*.whl
 	@echo "Build is fine!"
 
+.PHONY: test
+test:
+	uv run --with-requirements test_requirements.txt pytest
+
 .PHONY: lint
 lint:
 	pre-commit run -a
+
+.PHONY: docs-linkcheck
+docs-linkcheck:
+	@uv run pulp-linkchecker \
+		$$(git ls-files | grep '^docs/**/.*md$$') \
+		&& echo "No broken links found"
 
 .PHONY: docs-ci
 docs-ci: clean

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ readme = "README.md"
 
 [project.scripts]
 pulp-docs = "pulp_docs.cli:main"
+pulp-linkchecker = "linkchecker.cli:main"
 
 [project.entry-points."mkdocs.plugins"]
 PulpDocs = "pulp_docs.plugin:PulpDocsPlugin"
@@ -34,7 +35,7 @@ PulpDocs = "pulp_docs.plugin:PulpDocsPlugin"
 ###########
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/pulp_docs"]
+packages = ["src/pulp_docs", "src/linkchecker"]
 
 [tool.hatch.build.targets.wheel.force-include]
 # enable using the installed package directly for development

--- a/src/linkchecker/__init__.py
+++ b/src/linkchecker/__init__.py
@@ -1,0 +1,5 @@
+from linkchecker.cli import linkchecker
+
+__all__ = [
+    "linkchecker",
+]

--- a/src/linkchecker/cli.py
+++ b/src/linkchecker/cli.py
@@ -1,0 +1,162 @@
+import argparse
+import os
+from typing import NamedTuple
+
+HEADER_ERROR = "Found {n} broken link(s):"
+
+
+class LinkError(NamedTuple):
+    link_target: str
+    src_filename: str
+    src_line: str
+    src_lineno: int
+
+
+class LinkChecker:
+    def __init__(self, basedir: str):
+        self._relative_path, self._component_name = os.path.split(basedir)
+
+    def is_valid(self, link: str) -> bool:
+        """Return True if link is valid or should be ignored."""
+        rel_link, _ = self._normalize_link(link)
+        if self._should_skip(rel_link):
+            return True
+        abs_link = os.path.join(self._relative_path, rel_link)
+        return file_exists(abs_link)
+
+    def _should_skip(self, link: str) -> bool:
+        if not link.startswith(f"{self._component_name}/"):
+            return True
+        if link.strip("/") == f"{self._component_name}/restapi":
+            return True
+        return False
+
+    def _normalize_link(self, link: str):
+        link = link.removeprefix("site:")
+        link, _, query_string = link.partition("#")
+        link = link.strip()
+        return link, query_string
+
+
+def linkchecker(component_rootdir: str, filenames: list[str], verbose: bool = False) -> int:
+    checker = LinkChecker(component_rootdir)
+    cumulative_errors = []
+    for file in filenames:
+        if verbose:
+            print(f"== Checking: {file}")
+        link_errors = check_file(file, checker)
+        if not link_errors:
+            continue
+        cumulative_errors.extend(link_errors)
+    report_errors(link_errors=cumulative_errors, component_rootdir=component_rootdir)
+    if cumulative_errors:
+        return 1
+    return 0
+
+
+def check_file(src_filename: str, checker: LinkChecker) -> list[LinkError]:
+    link_errors = []
+    with open(src_filename, "r") as fd:
+        for src_lineno, src_line in enumerate(fd):
+            invalid_links = check_line(src_line, checker)
+            for link_target in invalid_links:
+                link_error = LinkError(
+                    link_target=link_target,
+                    src_line=src_line,
+                    src_filename=src_filename,
+                    src_lineno=src_lineno,
+                )
+                link_errors.append(link_error)
+    return link_errors
+
+
+def check_line(line: str, checker: LinkChecker) -> list[str]:
+    """Return invalid links in line."""
+    return [link for link in extract_links(line) if not checker.is_valid(link)]
+
+
+def extract_links(line: str) -> list[str]:
+    """Extract site: links from a markdown line."""
+    import re
+
+    links = []
+    # Match inline links: [text](site:path)
+    inline_pattern = r"\[([^\]]*)\]\((site:[^\)]*)\)"
+    # Match reference links: [ref]: site:path
+    reference_pattern = r"\[[^\]]*\]:\s*(site:[^\s]*)"
+
+    for match in re.finditer(inline_pattern, line):
+        links.append(match.group(2))
+    for match in re.finditer(reference_pattern, line):
+        links.append(match.group(1))
+
+    return links
+
+
+def file_exists(file: str) -> bool:
+    """Check if a file exists, treating .md extension as optional."""
+    file = os.path.realpath(file)
+    if os.path.exists(file):
+        return True
+    # Try with .md extension
+    if os.path.exists(file + ".md"):
+        return True
+    return False
+
+
+def report_errors(link_errors: list[LinkError], component_rootdir: str):
+    """Print link errors to stdout."""
+    if not link_errors:
+        return
+    print(HEADER_ERROR.format(n=len(link_errors)))
+    for error in link_errors:
+        filename = os.path.relpath(error.src_filename, component_rootdir)
+        lineno = error.src_lineno + 1
+        print(f"{filename}:{lineno}  {error.link_target}")
+
+
+def parse_arguments():
+    """Parse command line arguments."""
+
+    parser = argparse.ArgumentParser(description="Check markdown links")
+    parser.add_argument(
+        "--basedir",
+        default=".",
+        help="Base directory for link checking (default: current directory)",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Print each file as it is being checked",
+    )
+    parser.add_argument("files", nargs="+", help="Markdown files to check")
+    args = parser.parse_args()
+
+    # Shell-expand and normalize the basedir path
+    basedir = os.path.expanduser(args.basedir)
+    basedir = os.path.expandvars(basedir)
+    basedir = os.path.abspath(basedir)
+
+    if not os.path.exists(basedir):
+        parser.error(f"basedir does not exist: {basedir}")
+    if not os.path.isdir(basedir):
+        parser.error(f"basedir is not a directory: {basedir}")
+
+    for f in args.files:
+        if not os.path.exists(f):
+            parser.error(f"file does not exist: {f}")
+        if os.path.isdir(f):
+            parser.error(f"expected a file but got a directory: {f}")
+
+    return basedir, args.files, args.verbose
+
+
+def main():
+    """CLI entry point for the linkchecker command."""
+    basedir, files, verbose = parse_arguments()
+    exit(linkchecker(basedir, files, verbose))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+from textwrap import dedent
+from typing import Sequence
+
+import pytest
+
+
+def scenario_ids(cases: Sequence) -> list[str]:
+    return [c.name for c in cases]
+
+
+@pytest.fixture
+def create_file(tmp_path: Path):
+    def _create_file(filename: str, content: str) -> Path:
+        if not filename:
+            raise ValueError("filename can't be empty")
+        newfile = tmp_path / filename
+        newfile.parent.mkdir(parents=True, exist_ok=True)
+        newfile.write_text(dedent(content))
+        return newfile
+
+    return _create_file
+
+
+@pytest.fixture
+def create_tree(create_file, tmp_path):
+    def _create_tree(tree_text: str) -> tuple[Path, list[Path]]:
+        files = []
+        fragments = dedent(tree_text).split("=== ")
+        for fragment in fragments:
+            if not fragment.strip():
+                continue
+            filename, content = fragment.split("\n", maxsplit=1)
+            content = content.strip() or f"Placeholder for {filename=}"
+            files.append(create_file(filename.strip(), content))
+        return tmp_path, files
+
+    return _create_tree

--- a/tests/test_linkchecker.py
+++ b/tests/test_linkchecker.py
@@ -1,0 +1,232 @@
+from textwrap import dedent
+from typing import NamedTuple
+
+import pytest
+
+from linkchecker.cli import HEADER_ERROR, extract_links, linkchecker
+
+from .conftest import scenario_ids
+
+
+class Scenario(NamedTuple):
+    name: str
+    tree: str
+    component_dir: str
+    exit_code: int
+    output: str
+
+
+class LinkExtractionCase(NamedTuple):
+    name: str
+    line: str
+    expected_links: list[str]
+
+
+COMMON_TREE = """
+=== A/docs/guides/foo.md
+Content from file foo, repository A
+=== A/docs/reference/bar.md
+Content from file bar, repository A
+=== B/docs/guides/foo.md
+Content from file foo, repository B
+=== B/docs/reference/bar.md
+Content from file bar, repository B
+"""
+
+cases = [
+    Scenario(
+        name="valid_links",
+        tree=f"""
+            === A/docs/index.md
+            [valid](site:A/docs/guides/foo)
+            [valid](site:A/docs/guides/foo.md)
+
+            [valid]: site:A/docs/reference/bar
+            [valid]: site:A/docs/reference/bar.md
+            {COMMON_TREE}
+        """,
+        component_dir="A",
+        exit_code=0,
+        output="",
+    ),
+    Scenario(
+        name="valid_links_trailing_slash",
+        tree=f"""
+            === A/docs/index.md
+            [valid trailing slash](site:A/docs/guides/foo/)
+            [valid ref trailing slash]: site:A/docs/reference/bar/
+            {COMMON_TREE}
+        """,
+        component_dir="A",
+        exit_code=0,
+        output="",
+    ),
+    Scenario(
+        name="restapi_ignored",
+        tree=f"""
+            === A/docs/index.md
+            [restapi](site:A/restapi/#some-operation)
+            [restapi ref]: site:A/restapi/#another-operation
+            {COMMON_TREE}
+        """,
+        component_dir="A",
+        exit_code=0,
+        output="",
+    ),
+    Scenario(
+        name="missing_files",
+        tree=f"""
+            === A/docs/index.md
+            [valid](site:A/docs/guides/foo)
+            [valid](site:A/docs/reference/bar)
+            [invalid](site:A/docs/guides/NOEXIT.md)
+            [invalid](site:A/docs/reference/NOEXIT.md)
+            {COMMON_TREE}
+        """,
+        component_dir="A",
+        exit_code=1,
+        output=f"""
+            {HEADER_ERROR.format(n=2)}
+            docs/index.md:3  site:A/docs/guides/NOEXIT.md
+            docs/index.md:4  site:A/docs/reference/NOEXIT.md
+        """,
+    ),
+]
+
+
+@pytest.mark.parametrize("case", cases, ids=scenario_ids(cases))
+def test_linkchecker_main(case: Scenario, create_tree, capsys):
+    """Test checking all files in the docs directory."""
+    basedir, files = create_tree(case.tree)
+    exit_code = linkchecker(str(basedir / case.component_dir), files)
+    out, err = capsys.readouterr()
+    assert exit_code == case.exit_code
+    assert out.strip() == dedent(case.output).strip()
+
+
+class TestExtractLinks:
+    not_found_cases = [
+        LinkExtractionCase(
+            name="empty_line",
+            line="",
+            expected_links=[],
+        ),
+        LinkExtractionCase(
+            name="no_links",
+            line="Plain text with no links",
+            expected_links=[],
+        ),
+        LinkExtractionCase(
+            name="link_without_site_prefix",
+            line="[text](A/docs/foo)",
+            expected_links=[],
+        ),
+        LinkExtractionCase(
+            name="http_link_ignored",
+            line="[text](http://example.com)",
+            expected_links=[],
+        ),
+        LinkExtractionCase(
+            name="https_link_ignored",
+            line="[text](https://example.com)",
+            expected_links=[],
+        ),
+        LinkExtractionCase(
+            name="reference_without_site_prefix",
+            line="[ref]: A/docs/foo",
+            expected_links=[],
+        ),
+        LinkExtractionCase(
+            name="reference_http_link_ignored",
+            line="[ref]: http://example.com",
+            expected_links=[],
+        ),
+    ]
+
+    success_cases = [
+        LinkExtractionCase(
+            name="single_inline_link",
+            line="[text](site:A/docs/foo)",
+            expected_links=["site:A/docs/foo"],
+        ),
+        LinkExtractionCase(
+            name="single_reference_link",
+            line="[ref]: site:A/docs/foo",
+            expected_links=["site:A/docs/foo"],
+        ),
+        LinkExtractionCase(
+            name="multiple_inline_links",
+            line="[link1](site:A/docs/foo) and [link2](site:B/docs/bar)",
+            expected_links=["site:A/docs/foo", "site:B/docs/bar"],
+        ),
+        LinkExtractionCase(
+            name="mixed_inline_and_reference",
+            line="[inline](site:A/docs/foo) and [ref]: site:B/docs/bar",
+            expected_links=["site:A/docs/foo", "site:B/docs/bar"],
+        ),
+        LinkExtractionCase(
+            name="link_with_hash",
+            line="[link](site:A/docs/foo#section)",
+            expected_links=["site:A/docs/foo#section"],
+        ),
+        LinkExtractionCase(
+            name="link_with_hash_and_hyphen",
+            line="[link](site:A/docs/foo#section-1)",
+            expected_links=["site:A/docs/foo#section-1"],
+        ),
+        LinkExtractionCase(
+            name="empty_link_text",
+            line="[](site:A/docs/foo)",
+            expected_links=["site:A/docs/foo"],
+        ),
+        LinkExtractionCase(
+            name="link_with_trailing_slash",
+            line="[text](site:A/docs/foo/)",
+            expected_links=["site:A/docs/foo/"],
+        ),
+        LinkExtractionCase(
+            name="link_with_surrounding_text",
+            line="Text before [link](site:A/docs/foo) text after",
+            expected_links=["site:A/docs/foo"],
+        ),
+        LinkExtractionCase(
+            name="link_with_multiple_path_segments",
+            line="[link](site:A/docs/guides/installation)",
+            expected_links=["site:A/docs/guides/installation"],
+        ),
+        LinkExtractionCase(
+            name="reference_with_extra_spaces",
+            line="[ref]:   site:A/docs/foo",
+            expected_links=["site:A/docs/foo"],
+        ),
+        LinkExtractionCase(
+            name="link_text_with_spaces",
+            line="[link text with spaces](site:A/docs/foo)",
+            expected_links=["site:A/docs/foo"],
+        ),
+        LinkExtractionCase(
+            name="duplicate_links",
+            line="[link](site:A/docs/foo) [link](site:A/docs/foo)",
+            expected_links=["site:A/docs/foo", "site:A/docs/foo"],
+        ),
+        LinkExtractionCase(
+            name="empty_path_after_site",
+            line="[text](site:)",
+            expected_links=["site:"],
+        ),
+        LinkExtractionCase(
+            name="link_with_hyphens_and_underscores",
+            line="[link](site:A/docs/foo-bar_baz)",
+            expected_links=["site:A/docs/foo-bar_baz"],
+        ),
+    ]
+
+    @pytest.mark.parametrize("case", not_found_cases, ids=scenario_ids(not_found_cases))
+    def test_doesnt_return_links(self, case: LinkExtractionCase):
+        """Test extract_links returns empty list when no site: links are present."""
+        assert extract_links(case.line) == []
+
+    @pytest.mark.parametrize("case", success_cases, ids=scenario_ids(success_cases))
+    def test_return_links(self, case: LinkExtractionCase):
+        """Test extract_links correctly extracts site: links."""
+        assert extract_links(case.line) == case.expected_links

--- a/tests/test_testutils.py
+++ b/tests/test_testutils.py
@@ -1,0 +1,26 @@
+def test_create_tree(create_tree):
+    tree = """
+    === docs/index.md
+    # hello world
+
+    [foo](bar.md)
+
+    === docs/foo.md
+    This is the foo file
+    """
+    rootdir, files = create_tree(tree)
+    created_file_content = {}
+    for file in rootdir.rglob("*"):
+        if not file.is_file():
+            continue
+        content = file.read_text()
+        created_file_content[str(file.relative_to(rootdir))] = content
+
+    assert len(files) == 2
+    assert sorted(created_file_content.keys()) == ["docs/foo.md", "docs/index.md"]
+
+    assert "[foo](bar.md)" in created_file_content["docs/index.md"]
+    assert "[foo](bar.md)" not in created_file_content["docs/foo.md"]
+
+    assert "This is the foo file" in created_file_content["docs/foo.md"]
+    assert "This is the foo file" not in created_file_content["docs/index.md"]


### PR DESCRIPTION
Add a link checker cli tool to pulp-docs.
In a first pass, the link checker is designed to only look for internal links that uses `site:PATH` syntax.
Probably we want to improve that later.

Closes #34 
