### PR TITLE
Fix openapi-generation isolation problem among plugins

### DIFF
--- a/src/pulp_docs/openapi.py
+++ b/src/pulp_docs/openapi.py
@@ -50,8 +50,10 @@ class OpenAPIGenerator:
     DRY_RUN_SPECFILE_TEMPLATE = "dry-run specfile for: {plugin_label}"
 
     def __init__(self, plugins: list[OpenApiPlugin], dry_run: bool = False):
-        self.plugins = plugins
-        self.repository_paths = list({p.repository_path for p in plugins if p.repository_path})
+        missing = [p.plugin_label for p in plugins if not p.repository_path]
+        if missing:
+            raise ValueError(f"Plugins missing repository path: {missing}")
+        self.label_to_path = {p.plugin_label: p.repository_path for p in plugins}
         self.dry_run = dry_run
 
     def generate(self) -> dict[str, Path]:
@@ -59,21 +61,21 @@ class OpenAPIGenerator:
 
         Returns map of plugin labels to generated spec path.
         """
-        if not self.plugins:
+        if not self.label_to_path:
             return {}
         output_dir = Path(tempfile.mkdtemp())
         label_to_specfile = {}
-        for plugin in self.plugins:
-            filename = f"{plugin.plugin_label}-api.json"
+        for label in self.label_to_path:
+            filename = f"{label}-api.json"
             file_path = output_dir / filename
-            self._generate_schema(plugin.plugin_label, file_path)
-            label_to_specfile[plugin.plugin_label] = file_path
+            self._generate_schema(label, file_path)
+            label_to_specfile[label] = file_path
         return label_to_specfile
 
     def _generate_schema(self, plugin_label: str, output_file: Path):
         cmd = ["uv", "run", "--isolated", "--with", "setuptools"]
-        for repo_path in self.repository_paths:
-            cmd.extend(["--with", str(repo_path.resolve())])
+        repo_path = self.label_to_path[plugin_label]
+        cmd.extend(["--with", str(repo_path.resolve())])
         cmd.extend(
             ["pulpcore-manager", "openapi", "--component", plugin_label, "--file", str(output_file)]
         )

--- a/tests/test_openapi_generation.py
+++ b/tests/test_openapi_generation.py
@@ -22,13 +22,14 @@ def repositories(tmp_path_factory: pytest.TempPathFactory) -> dict[str, OpenApiP
 
 
 class TestOpenAPIGenerator:
-    def test_deduplicate_repository_paths(self, repositories: dict[str, OpenApiPlugin]):
-        """pulpcore and pulp_file share the same repository path."""
+    def test_label_to_path_mapping(self, repositories: dict[str, OpenApiPlugin]):
+        """Each plugin label maps to its repository path."""
         filter = ["rpm", "file", "core"]
         plugins = [p for p in repositories.values() if p.plugin_label in filter]
         gen = OpenAPIGenerator(plugins, dry_run=True)
-        # pulpcore and pulp_file share the same repository
-        assert len(gen.repository_paths) == 2
+        assert len(gen.label_to_path) == len(plugins)
+        for plugin in plugins:
+            assert gen.label_to_path[plugin.plugin_label] == plugin.repository_path
 
     @pytest.mark.parametrize(
         "filter",


### PR DESCRIPTION
The publishing workflow is failing due to dependency issues with existing plugins when generating their openapi specs (uses uv as subprocess to call pulpcore-manager openapi command).

Each openapi spec generation call to a specific plugin would install all available plugins. Each generation should be isolated and not interfere with one another.

Sample error:

```
Error message:
Because only pulp-rpm==3.39.0.dev0 is available and
      pulp-rpm==3.39.0.dev0 depends on pulpcore>=3.111.0,<3.115,
      we can conclude that all versions of pulp-rpm depend on
      pulpcore>=3.111.0,<3.115.
      And because only the following versions of pulpcore are available:
          pulpcore<3.111.0
          pulpcore>=3.115
      and you require pulp-rpm, we can conclude that your requirements are
      unsatisfiable.

Aborted with a BuildError!
make: *** [Makefile:61: docs-prod] Error 1
```