### PR TITLE
Fix quick links page

### DIFF
--- a/pulpproject.org/help/more/quick-links.md
+++ b/pulpproject.org/help/more/quick-links.md
@@ -23,11 +23,3 @@ Component | Version | Links | &nbsp; | &nbsp;
 {{ component.title }} | `{{ component.version }}` | {{ component.links | join(" | ") }}
 {%- endfor %}
 {%- endfor %}
-
-## Changes RSS Feed
-
-Check our recent releases with this [RSS changelog feed](https://himdel.eu/feed/pulp-changes.json).
-
-{% for item in rss_items() %}
-- [{{ item.title }}]({{ item.url }})
-{% endfor %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
     "mkdocs-macros-plugin~=1.3.7",
     "mkdocs-site-urls~=0.2.0",
     "mkdocs-literate-nav~=0.6.1",
-    "httpx",
     "rich",
     "uv",
     "GitPython~=3.1.44",

--- a/src/pulp_docs/plugin.py
+++ b/src/pulp_docs/plugin.py
@@ -7,7 +7,6 @@ from collections import defaultdict
 from dataclasses import dataclass, replace
 from pathlib import Path
 
-import httpx
 import yaml
 from git import Repo
 from mkdocs.config import Config, config_options, load_config
@@ -420,22 +419,6 @@ def get_component_data(
     }
 
 
-def rss_items() -> list:
-    # that's Himdel's rss feed: https://github.com/himdel
-    # TODO move this fetching to js.
-    response = httpx.get("https://himdel.eu/feed/pulp-changes.json")
-    if response.is_error:
-        return [
-            {
-                "url": "#",
-                "title": "Could not fetch the feed. Please, open an issue in https://github.com/pulp/pulp-docs/.",
-            }
-        ]
-
-    rss_feed = json.loads(response.content)
-    return rss_feed["items"][:20]
-
-
 def log_pulp_config(
     mkdocs_file: str, path: list[str], loaded_components: list[LoadedComponent], site_dir: str
 ):
@@ -501,7 +484,6 @@ class PulpDocsPlugin(BasePlugin[PulpDocsPluginConfig]):
             mkdocstrings_config.handlers["python"]["paths"].append(str(component_dir / "src"))
 
         macros_plugin = config.plugins["macros"]
-        macros_plugin.register_macros({"rss_items": rss_items})
         macros_plugin.register_variables({"components": components_var})
 
         blog_plugin = config.plugins["material/blog"]


### PR DESCRIPTION
The quick links page depended on an external feed (himdel.eu) fetched at build time via httpx.
When that service returns empty responses, the page fails to render entirely.

This remove the RSS feed section, the rss_items macro, and the httpx dependency to eliminate external service dependencies from the site build.

The rss is cool, but Pulp should own such a service (and not depend on external 3rd party ones).