### PR TITLE
Add Licensing Notice page and improve governance visibility

### DIFF
--- a/custom/main.html
+++ b/custom/main.html
@@ -1,1 +1,56 @@
 {% extends "base.html" %}
+
+{% block footer %}
+<footer class="md-footer">
+  {% if "navigation.footer" in features %}
+    {% if page.previous_page or page.next_page %}
+      {% if page.meta and page.meta.hide %}
+        {% set hidden = "hidden" if "footer" in page.meta.hide %}
+      {% endif %}
+      <nav class="md-footer__inner md-grid" aria-label="{{ lang.t('footer') }}" {{ hidden }}>
+        {% if page.previous_page %}
+          {% set direction = lang.t("footer.previous") %}
+          <a href="{{ page.previous_page.url | url }}" class="md-footer__link md-footer__link--prev" aria-label="{{ direction }}: {{ page.previous_page.title | e }}">
+            <div class="md-footer__button md-icon">
+              {% set icon = config.theme.icon.previous or "material/arrow-left" %}
+              {% include ".icons/" ~ icon ~ ".svg" %}
+            </div>
+            <div class="md-footer__title">
+              <span class="md-footer__direction">{{ direction }}</span>
+              <div class="md-ellipsis">{{ page.previous_page.title }}</div>
+            </div>
+          </a>
+        {% endif %}
+        {% if page.next_page %}
+          {% set direction = lang.t("footer.next") %}
+          <a href="{{ page.next_page.url | url }}" class="md-footer__link md-footer__link--next" aria-label="{{ direction }}: {{ page.next_page.title | e }}">
+            <div class="md-footer__title">
+              <span class="md-footer__direction">{{ direction }}</span>
+              <div class="md-ellipsis">{{ page.next_page.title }}</div>
+            </div>
+            <div class="md-footer__button md-icon">
+              {% set icon = config.theme.icon.next or "material/arrow-right" %}
+              {% include ".icons/" ~ icon ~ ".svg" %}
+            </div>
+          </a>
+        {% endif %}
+      </nav>
+    {% endif %}
+  {% endif %}
+  <div class="md-footer-meta md-typeset">
+    <div class="md-footer-custom">
+      <div class="md-footer-links">
+        <a href="{{ 'help/more/governance/privacy/' | url }}">Privacy Policy</a>
+        <a href="{{ 'help/more/governance/code-of-conduct/' | url }}">Code of Conduct</a>
+        <a href="{{ 'help/more/governance/ai_policy/' | url }}">AI Policy</a>
+      </div>
+    </div>
+    <div class="md-footer-meta__inner md-grid">
+      {% include "partials/copyright.html" %}
+      {% if config.extra.social %}
+        {% include "partials/social.html" %}
+      {% endif %}
+    </div>
+  </div>
+</footer>
+{% endblock %}

--- a/custom/main.html
+++ b/custom/main.html
@@ -40,6 +40,7 @@
   <div class="md-footer-meta md-typeset">
     <div class="md-footer-custom">
       <div class="md-footer-links">
+        <a href="{{ 'help/more/governance/licenses/' | url }}">Licensing Notice</a>
         <a href="{{ 'help/more/governance/privacy/' | url }}">Privacy Policy</a>
         <a href="{{ 'help/more/governance/code-of-conduct/' | url }}">Code of Conduct</a>
         <a href="{{ 'help/more/governance/ai_policy/' | url }}">AI Policy</a>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -242,4 +242,5 @@ markdown_extensions:
   - pymdownx.tilde
 
 copyright: |
-  &copy; 2025 <a href="https://github.com/pulp"  target="_blank" rel="noopener">Pulp Project</a>
+  &copy; 2026 <a href="https://github.com/pulp"  target="_blank" rel="noopener">Pulp Project</a>.
+  Website licensed under <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener">CC BY-SA 4.0</a>.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,7 +48,22 @@ nav:
     - "dev/index.md"
   - Blog:
     - "blog/index.md"
-  - Help: "help/"
+  - Help:
+    - "help/index.md"
+    - Community:
+      - "help/community/get-involved.md"
+      - "help/community/pulpcon.md"
+      - "help/community/publish-to-blog.md"
+    - More:
+      - "help/more/why-pulp.md"
+      - "help/more/quick-links.md"
+      - "help/more/brand-guide.md"
+      - "help/more/docs-usage.md"
+    - Governance:
+      - "help/more/governance/licenses.md"
+      - "help/more/governance/privacy.md"
+      - "help/more/governance/code-of-conduct.md"
+      - "help/more/governance/ai_policy.md"
 plugins:
   - PulpDocs:
       components:

--- a/pulpproject.org/css/extra.css
+++ b/pulpproject.org/css/extra.css
@@ -38,6 +38,54 @@
   line-height: 1.1;
 }
 
+.md-footer-links {
+  display: flex;
+  gap: 1.5rem;
+  justify-content: center;
+  padding: 0.4rem 0;
+}
+
+.md-footer-links a {
+  color: var(--md-footer-fg-color--lighter);
+  font-size: 0.7rem;
+}
+
+.md-footer-links a:hover {
+  color: var(--md-footer-fg-color);
+}
+
+.md-footer-license {
+  text-align: center;
+  font-size: 0.7rem;
+  color: var(--md-footer-fg-color--lighter);
+}
+
+.md-footer-license a {
+  color: var(--md-footer-fg-color--lighter);
+}
+
+.md-footer-license a:hover {
+  color: var(--md-footer-fg-color);
+}
+
+.md-copyright__highlight {
+  color: var(--md-footer-fg-color--lighter);
+}
+
+.md-copyright__highlight a {
+  color: var(--md-footer-fg-color--lighter);
+}
+
+.md-copyright__highlight a:hover {
+  color: var(--md-footer-fg-color);
+}
+
+.md-footer-custom {
+  display: flex;
+  justify-content: center;
+  padding: 0.2rem 0;
+}
+
 :root {
   --md-primary-fg-color:        #347dbe;
   --md-primary-fg-color--light: #ECB7B7;

--- a/pulpproject.org/help/more/governance/licenses.md
+++ b/pulpproject.org/help/more/governance/licenses.md
@@ -1,0 +1,14 @@
+# Licensing Notice
+
+## Website Content
+
+The site design, original text, and curated content on this website are licensed under the
+[Creative Commons Attribution-ShareAlike 4.0 International License (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/).
+
+## Aggregated Projects
+
+The software documentation aggregated on this site comes from multiple Pulp Project repositories.
+Each repository is governed by its own open-source license.
+Please refer to each project's repository for specific licensing terms.
+
+You can find links to all project repositories on the [Quick Links](site:help/more/quick-links/) page.


### PR DESCRIPTION
This PR does:

- Add licensing notice page to clarify the website vs individual repository licenses
- Add links to governance pages in the footer and include website copyright info (CC)
- Move Governance section up in nav hierarchy

## Licensing Notice and new sidebar nav

<img width="1179" height="614" alt="image" src="https://github.com/user-attachments/assets/0d8497a1-a33f-41ca-a585-8de1c30262e7" />

## New footer

<img width="1479" height="220" alt="image" src="https://github.com/user-attachments/assets/96486afd-5ee3-4a32-bc3b-d6ed5ce93671" />
